### PR TITLE
Get mso-test ready for running in Jenkins

### DIFF
--- a/Properties/app.manifest
+++ b/Properties/app.manifest
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+      <applicationRequestMinimum>
+        <PermissionSet class="System.Security.PermissionSet" version="1" Unrestricted="true" ID="Custom" SameSite="site" />
+        <defaultAssemblyRequest permissionSetReference="Custom" />
+      </applicationRequestMinimum>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+    </application>
+  </compatibility>
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  -->
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+</assembly>

--- a/jenkins.ps1
+++ b/jenkins.ps1
@@ -1,0 +1,20 @@
+# Call as `powershell.exe -File jenkins.ps1 -app word`
+# app can be "word" or "excel" or "powerpoint"
+
+param([Parameter(Mandatory=$true)][string]$app)
+if ($app -ne "word" -and $app -ne "excel" -and $app -ne "powerpoint") {
+	echo "Bad argument"
+	exit 1
+}
+
+.\mso-test.exe "$app" | tee -filepath "output_$app.txt"
+$failures = Select-String -Path "output_$app.txt" -Pattern "Fail:"
+
+if ($failures -ne $null) {
+	echo Failures:
+	echo $failures
+	exit 1
+} else {
+	echo No failures
+	exit 0
+}

--- a/mso-test.csproj
+++ b/mso-test.csproj
@@ -55,10 +55,16 @@
     <ManifestKeyFile>mso-test_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <GenerateManifests>true</GenerateManifests>
+    <GenerateManifests>false</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetZone>LocalIntranet</TargetZone>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -81,6 +87,7 @@
     <None Include="downloadExcelData.sh" />
     <None Include="downloadTestData.sh" />
     <None Include="packages.config" />
+    <None Include="Properties\app.manifest" />
     <None Include="resetFailed.bat" />
     <None Include="runPowerpointTest.bat" />
     <None Include="runExcelTest.bat" />


### PR DESCRIPTION
Prints failure message instead of renaming files
Also adds a powershell script to be called from Jenkins
The script scans the output for the failure messages

This does change the behavior a bit. Files will be retested even if they failed last time. I think this is desirable. We should investigate and manually skip tests (perhaps by manually renaming them to *.failed as before). We do not want to accidentally forget to look at a job, and then never see the failure again.

Another behavior change is that it also now reconverts the files every time. I think this is also desirable. Collabora online is not running on the local computer, so we have to call into staging.eu to convert the files, testing the conversion of whatever system is running there. We do not want to convert them once today, and then reopen the same file over and over forever.

We might need to make changes to FileHandling.cs too if files don't get renamed to *.failed automatically. Or it might not be needed any more. I didn't look at it much so I'm not sure exactly what it does or if it needs to be changed.

The csproj files were changed by Visual Studio and found by git. I know very little about C# so I don't know if they are necessary.