### PR TITLE
Improve bmp regression performance

### DIFF
--- a/create-flamegraph.sh
+++ b/create-flamegraph.sh
@@ -55,4 +55,9 @@ sudo perf record -F 99 -g -- sh -c '
 # Process perf data
 sudo perf script > out.perf
 "$mso_dir/FlameGraph/stackcollapse-perf.pl" out.perf > out.folded
-"$mso_dir/FlameGraph/flamegraph.pl" out.folded > flamegraph.svg
+"$mso_dir/FlameGraph/flamegraph.pl" out.folded > ../converted/flamegraph.svg
+
+# Files were created with sudo, change ownership to the user, so that they can be deleted later
+sudo chown -R $USER:$USER ../converted
+sudo chown -R $USER:$USER ../download
+sudo chown -R $USER:$USER ../history

--- a/create-flamegraph.sh
+++ b/create-flamegraph.sh
@@ -31,7 +31,6 @@ rm -f flamegraph.svg
 sudo perf record -F 99 -g -- sh -c '
     find ../download/doc/ -name "*.doc" -execdir basename {} \; \
     | xargs -L1 -I{} python3 '"$mso_dir"'/diff-pdf-page-statistics.py \
-        --no_save_overlay \
         --base_file="{}" \
         --image_dump
 '

--- a/create-flamegraph.sh
+++ b/create-flamegraph.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Usage: cd history && /path/to/mso/create-flamegraph.sh /path/to/mso
+# The file structure required:
+# |--- history/
+# |    |--- ext/
+# |--- download/
+# |    |--- ext/
+# |--- converted/
+# |    |--- ext/
+# To run the script, you need to be inside the history/ directory
+# To view the flamegraph, open history/flamegraph.svg in a web browser
+
 mso_dir="$1"
 
 if [ -z "$mso_dir" ]; then

--- a/create-flamegraph.sh
+++ b/create-flamegraph.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+mso_dir="$1"
+
+if [ -z "$mso_dir" ]; then
+    echo "Pass the directory for the image regression test"
+    exit 1
+fi
+
+if [ ! -d "$mso_dir/FlameGraph" ]; then
+    git clone https://github.com/brendangregg/FlameGraph "$mso_dir/FlameGraph"
+fi
+
+# Clean up old perf data
+rm -f perf.data
+rm -f out.perf
+rm -f out.folded
+rm -f flamegraph.svg
+
+sudo perf record -F 99 -g -- sh -c '
+    find ../download/doc/ -name "*.doc" -execdir basename {} \; \
+    | xargs -L1 -I{} python3 '"$mso_dir"'/diff-pdf-page-statistics.py \
+        --no_save_overlay \
+        --base_file="{}" \
+        --image_dump
+'
+
+# Process perf data
+sudo perf script > out.perf
+"$mso_dir/FlameGraph/stackcollapse-perf.pl" out.perf > out.folded
+"$mso_dir/FlameGraph/flamegraph.pl" out.folded > flamegraph.svg

--- a/create-flamegraph.sh
+++ b/create-flamegraph.sh
@@ -28,6 +28,8 @@ rm -f out.perf
 rm -f out.folded
 rm -f flamegraph.svg
 
+make -C "$mso_dir" clean && make -C "$mso_dir" debug
+
 sudo perf record -F 99 -g -- sh -c '
     find ../download/doc/ -name "*.doc" -execdir basename {} \; \
     | xargs -L1 -I{} python3 '"$mso_dir"'/diff-pdf-page-statistics.py \

--- a/create-flamegraph.sh
+++ b/create-flamegraph.sh
@@ -12,10 +12,19 @@
 # To view the flamegraph, open history/flamegraph.svg in a web browser
 
 mso_dir="$1"
-doc_name="$2"
+ext="$2"
+doc_name="$3"
 
 if [ -z "$mso_dir" ]; then
     echo "Pass the directory for the image regression test"
+    exit 1
+fi
+
+if [ -z "$ext" ]; then
+    echo "No file extension passed, for example 'pptx', 'ppt, 'docx', 'doc'"
+    exit 1
+elif [ "$ext" != "pptx" ] && [ "$ext" != "ppt" ] && [ "$ext" != "docx" ] && [ "$ext" != "doc" ]; then
+    echo "File extension must be 'pptx', 'ppt', 'docx' or 'doc'"
     exit 1
 fi
 
@@ -37,7 +46,7 @@ rm -f flamegraph.svg
 make -C "$mso_dir" clean && make -C "$mso_dir" debug
 
 sudo perf record -F 99 -g -- sh -c '
-    find ../download/doc/ -name '"$doc_name"' -execdir basename {} \; \
+    find ../download/'"$ext"'/ -name '"$doc_name"' -execdir basename {} \; \
     | xargs -L1 -I{} python3 '"$mso_dir"'/diff-pdf-page-statistics.py \
         --base_file="{}" \
         --image_dump

--- a/create-flamegraph.sh
+++ b/create-flamegraph.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: cd history && /path/to/mso/create-flamegraph.sh /path/to/mso
+# Usage: cd history && /path/to/mso/create-flamegraph.sh /path/to/mso [document_name.doc]
 # The file structure required:
 # |--- history/
 # |    |--- ext/
@@ -12,10 +12,16 @@
 # To view the flamegraph, open history/flamegraph.svg in a web browser
 
 mso_dir="$1"
+doc_name="$2"
 
 if [ -z "$mso_dir" ]; then
     echo "Pass the directory for the image regression test"
     exit 1
+fi
+
+if [ -z "$doc_name" ]; then
+    doc_name="*.doc"
+    echo "No document name passed, defaulting to *.doc"
 fi
 
 if [ ! -d "$mso_dir/FlameGraph" ]; then
@@ -31,7 +37,7 @@ rm -f flamegraph.svg
 make -C "$mso_dir" clean && make -C "$mso_dir" debug
 
 sudo perf record -F 99 -g -- sh -c '
-    find ../download/doc/ -name "*.doc" -execdir basename {} \; \
+    find ../download/doc/ -name '"$doc_name"' -execdir basename {} \; \
     | xargs -L1 -I{} python3 '"$mso_dir"'/diff-pdf-page-statistics.py \
         --base_file="{}" \
         --image_dump

--- a/diff-pdf-page-statistics.py
+++ b/diff-pdf-page-statistics.py
@@ -46,6 +46,7 @@ def printdebug(debug, *args, **kwargs):
     if debug:
         print(*args, **kwargs)
 def main():
+    start_time = time.perf_counter()
     parser = argparse.ArgumentParser(description="Look for import and export regressions.")
     parser.add_argument("--base_file", default="lorem ipsum.docx")
     parser.add_argument("--history_dir", default=".")
@@ -1215,22 +1216,16 @@ def main():
         STAMP_DIR = os.path.join(base_dir, "stamps/")
 
         options = [str(IS_FILE_LO_PREV).lower(), str(IS_FILE_MS_PREV).lower(), str(args.image_dump).lower(), str(args.no_save_overlay).lower(), str(args.minor_differences).lower()]
+
+        command = [PIXELBASHER_BIN] + [args.base_file] + ms_orig_pages + lo_pages + ms_conv_pages + lo_previous_pages + \
+                    ms_conv_previous_pages + [IMPORT_DIR] + [EXPORT_DIR] + [IMPORT_COMPARE_DIR] + [EXPORT_COMPARE_DIR] + \
+                    [IMAGE_DUMP_DIR] + [STAMP_DIR] + options
+        if DEBUG:
+            print(" ".join(command))
+
         # Run pixelbasher to compare differences between MSO and LO PDF pages
         subprocess.run(
-            [PIXELBASHER_BIN] +
-            [args.base_file] +
-            ms_orig_pages +
-            lo_pages +
-            ms_conv_pages +
-            lo_previous_pages +
-            ms_conv_previous_pages +
-            [IMPORT_DIR] +
-            [EXPORT_DIR] +
-            [IMPORT_COMPARE_DIR] +
-            [EXPORT_COMPARE_DIR] +
-            [IMAGE_DUMP_DIR] +
-            [STAMP_DIR] +
-            options,
+            command,
             check=True
         )
     except subprocess.CalledProcessError as e:
@@ -1254,6 +1249,8 @@ def main():
         if IS_FILE_MS_PREV:
             for page in ms_conv_previous_pages:
                 os.remove(page)
+        end_time = time.perf_counter()
+        print(f"Execution time: {end_time - start_time:0.4f} seconds")
 
 if __name__ == "__main__":
     main()

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ OBJS = $(patsubst $(SRC_DIR)/%.cpp, $(OBJ_DIR)/%.o, $(SRCS))
 # Default target
 all: release
 
-debug: CXXFLAGS += -g -DDEBUG
+debug: CXXFLAGS += -g
 debug: $(TARGET)
 
 release: CXXFLAGS += -O3 -DNDEBUG

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -std=c++20 -Wall -g -MMD -MP -mavx2
+CXXFLAGS = -std=c++20 -Wall -g -MMD -MP -mavx2 -O3
 SRC_DIR = src
 OBJ_DIR = obj
 TARGET = pixelbasher

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -std=c++20 -Wall -g -MMD -MP
+CXXFLAGS = -std=c++20 -Wall -g -MMD -MP -mavx2
 SRC_DIR = src
 OBJ_DIR = obj
 TARGET = pixelbasher

--- a/makefile
+++ b/makefile
@@ -1,11 +1,20 @@
 CXX = g++
-CXXFLAGS = -std=c++20 -Wall -g -MMD -MP -mavx2 -O3
+CXXFLAGS = -std=c++20 -Wall -MMD -MP -mavx2
 SRC_DIR = src
 OBJ_DIR = obj
 TARGET = pixelbasher
 
 SRCS = $(wildcard $(SRC_DIR)/*.cpp)
 OBJS = $(patsubst $(SRC_DIR)/%.cpp, $(OBJ_DIR)/%.o, $(SRCS))
+
+# Default target
+all: release
+
+debug: CXXFLAGS += -g -DDEBUG
+debug: $(TARGET)
+
+release: CXXFLAGS += -O3 -DNDEBUG
+release: $(TARGET)
 
 $(TARGET) : $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) -o $(TARGET)

--- a/src/bmp.cpp
+++ b/src/bmp.cpp
@@ -151,12 +151,19 @@ void BMP::write(std::string filename)
     }
 }
 
-void BMP::write_with_filter(const BMP &base, std::string filename, std::vector<uint8_t> filter_mask)
+void BMP::write_with_filter(const BMP &base, std::string filename, std::vector<uint64_t> filter_mask)
 {
     const int base_width = base.get_width();
     const int base_height = base.get_height();
     BMP copy(base);
     std::vector<uint8_t> copy_data = base.get_data();
+
+    auto get_bit = [&](const std::vector<uint64_t> &mask, int pixel_index) {
+        int array_index = pixel_index / 64;
+        int bit = pixel_index % 64;
+        return (mask[array_index] >> bit) & 1;
+    };
+
     for (int y = 0; y < base_height; y++)
     {
         for (int x = 0; x < base_width; x++)
@@ -164,7 +171,7 @@ void BMP::write_with_filter(const BMP &base, std::string filename, std::vector<u
             int index = y * base_width + x;
             int byte_index = index * pixel_stride;
 
-            if (filter_mask[index])
+            if (get_bit(filter_mask, index))
             {
                 copy_data[byte_index + 0] = 0;
                 copy_data[byte_index + 1] = 0;
@@ -376,37 +383,24 @@ void BMP::set_data_internal(std::vector<std::uint8_t> &new_data)
     m_data = new_data;
 }
 
-std::vector<uint8_t> BMP::blur_edge_mask() const
-{
-    std::vector<uint8_t> edge_map = sobel_edges<245>();
-    std::int32_t width = m_info_header.width;
-    std::int32_t height = m_info_header.height;
-    std::vector<uint8_t> blurred_mask(width * height, 0);
-
-    for (int y = 1; y < height - 1; y++)
-    {
-        for (int x = 1; x < width - 1; x++)
-        {
-            int index = y * width + x;
-
-            // If the current pixel is not an edge, skip it
-            if (!edge_map[index])
-                continue;
-
-            blur_pixels<2>(x, y, width, height, blurred_mask);
-        }
-    }
-    return blurred_mask;
-}
 
 template <int Threshold>
-std::vector<uint8_t> BMP::sobel_edges() const
+std::vector<uint64_t> BMP::sobel_edges() const
 {
     std::int32_t width = m_info_header.width;
     std::int32_t height = m_info_header.height;
     const std::vector<std::uint8_t> &data = m_data;
 
-    std::vector<uint8_t> result(width * height, 0);
+    int n_pixels = width * height;
+    int size = (n_pixels + 63) / 64;
+
+    std::vector<uint64_t> result(size, 0);
+
+    auto set_bit = [&](int pixel_index) {
+        int array_index = pixel_index / 64;
+        int bit = pixel_index % 64;
+        result[array_index] |= uint64_t(1) << bit;
+    };
 
     // Loop through each pixel in the image, skipping the edges to avoid out-of-bounds access
     for (int y = 1; y < height - 1; y++)
@@ -418,18 +412,99 @@ std::vector<uint8_t> BMP::sobel_edges() const
             // Calculate gradient magnitude (clamped to 255)
             int magnitude = std::min(255, static_cast<int>(std::sqrt(g_x * g_x + g_y * g_y)));
 
-            result[y * width + x] = (magnitude >= Threshold) ? 1 : 0;
+            if (magnitude >= Threshold) {
+                set_bit(y * width + x);
+            }
         }
     }
     return result;
 }
 
-std::vector<uint8_t> BMP::filter_long_vertical_edge_runs(int min_run_length) const
+template <int Threshold>
+std::vector<uint64_t> BMP::get_vertical_edges() const
 {
-    std::vector<uint8_t> vertical_edges = get_vertical_edges<245>();
-    std::vector<uint8_t> result(vertical_edges.size(), 0);
+    std::int32_t width = m_info_header.width;
+    std::int32_t height = m_info_header.height;
+    const std::vector<std::uint8_t> &data = m_data;
+
+    int n_pixels = width * height;
+    int size = (n_pixels + 63) / 64;
+    std::vector<uint64_t> result(size, 0);
+
+    auto set_bit = [&](int pixel_index) {
+        int array_index = pixel_index / 64;
+        int bit = pixel_index % 64;
+        result[array_index] |= uint64_t(1) << bit;
+    };
+
+    for (int y = 1; y < height - 1; y++)
+    {
+        for (int x = 1; x < width - 1; x++)
+        {
+            auto [g_x, g_y] = get_sobel_gradients(y, x, data, width);
+
+            int abs_gx = std::abs(g_x);
+
+            if (abs_gx >= Threshold) {
+                set_bit(y * width + x);
+            }
+        }
+    }
+    return result;
+}
+
+std::vector<uint64_t> BMP::blur_edge_mask() const
+{
+    std::vector<uint64_t> edge_map = sobel_edges<245>();
+
+    std::int32_t width = m_info_header.width;
+    std::int32_t height = m_info_header.height;
+
+    int n_pixels = width * height;
+    int size = (n_pixels + 63) / 64;
+    std::vector<uint64_t> blurred_mask(size, 0);
+
+    auto get_bit = [&](const std::vector<uint64_t> &mask, int pixel_index) {
+        int array_index = pixel_index / 64;
+        int bit = pixel_index % 64;
+        return (mask[array_index] >> bit) & 1;
+    };
+
+    for (int y = 1; y < height - 1; y++)
+    {
+        for (int x = 1; x < width - 1; x++)
+        {
+            int index = y * width + x;
+            if (get_bit(edge_map, index) == 0)
+                continue;
+
+            blur_pixels<2>(x, y, width, height, blurred_mask);
+        }
+    }
+    return blurred_mask;
+}
+
+std::vector<uint64_t> BMP::filter_long_vertical_edge_runs(int min_run_length) const
+{
+    std::vector<uint64_t> vertical_edges = get_vertical_edges<245>();
     int width = m_info_header.width;
     int height = m_info_header.height;
+
+    int n_pixels = width * height;
+    int size = (n_pixels + 63) / 64;
+    std::vector<uint64_t> result(size, 0);
+
+    auto get_bit = [&](const std::vector<uint64_t> &mask, int pixel_index) {
+        int array_index = pixel_index / 64;
+        int bit = pixel_index % 64;
+        return (mask[array_index] >> bit) & 1;
+    };
+
+    auto set_bit = [&](int pixel_index) {
+        int array_index = pixel_index / 64;
+        int bit = pixel_index % 64;
+        result[array_index] |= uint64_t(1) << bit;
+    };
 
     for (int x = 0; x < width; x++)
     {
@@ -439,7 +514,7 @@ std::vector<uint8_t> BMP::filter_long_vertical_edge_runs(int min_run_length) con
         for (int y = 0; y < height; y++)
         {
             int index = y * width + x;
-            if (vertical_edges[index])
+            if (get_bit(vertical_edges, index))
             {
                 if (run_start == -1)
                 {
@@ -454,7 +529,7 @@ std::vector<uint8_t> BMP::filter_long_vertical_edge_runs(int min_run_length) con
                     // copy the run
                     for (int i = run_start; i < run_start + run_length; i++)
                     {
-                        result[i * width + x] = 1;
+                        set_bit(i * width + x);
                     }
                 }
                 run_start = -1;
@@ -465,32 +540,15 @@ std::vector<uint8_t> BMP::filter_long_vertical_edge_runs(int min_run_length) con
     return result;
 }
 
-template <int Threshold>
-std::vector<uint8_t> BMP::get_vertical_edges() const
-{
-    std::int32_t width = m_info_header.width;
-    std::int32_t height = m_info_header.height;
-    const std::vector<std::uint8_t> &data = m_data;
-
-    std::vector<uint8_t> result(width * height, 0);
-
-    for (int y = 1; y < height - 1; y++)
-    {
-        for (int x = 1; x < width - 1; x++)
-        {
-            auto [g_x, g_y] = get_sobel_gradients(y, x, data, width);
-
-            int abs_gx = std::abs(g_x);
-
-            result[y * width + x] = (abs_gx >= Threshold) ? 1 : 0;
-        }
-    }
-    return result;
-}
-
 template <int Radius>
-void BMP::blur_pixels(int x, int y, int width, int height, std::vector<uint8_t> &mask)
+void BMP::blur_pixels(int x, int y, int width, int height, std::vector<uint64_t> &mask)
 {
+    auto set_bit = [&](int pixel_index) {
+        int array_index = pixel_index / 64;
+        int bit = pixel_index % 64;
+        mask[array_index] |= uint64_t(1) << bit;
+    };
+
     for (int dy = -Radius; dy <= Radius; dy++)
     {
         for (int dx = -Radius; dx <= Radius; dx++)
@@ -501,11 +559,40 @@ void BMP::blur_pixels(int x, int y, int width, int height, std::vector<uint8_t> 
             // Check if the new coordinates are within bounds
             if (new_x >= 0 && new_x < width && new_y >= 0 && new_y < height)
             {
-                mask[new_y * width + new_x] = 1;
+                set_bit(new_y * width + new_x);
             }
         }
     }
 }
+
+std::vector<uint64_t> BMP::calculate_intersection_mask_simd(const BMP &original, const BMP &target)
+{
+    const std::vector<uint64_t> original_edge_map = original.get_blurred_edge_mask();
+    const std::vector<uint64_t> target_edge_map = target.get_blurred_edge_mask();
+
+    int width = std::min(original.get_width(), target.get_width());
+    int height = std::min(original.get_height(), target.get_height());
+
+    int n_bits = width * height;
+    int size = (n_bits + 63) / 64;
+    std::vector<uint64_t> intersection_mask(size, 0);
+
+    int i = 0;
+    for (; i + 3 < size; i += 4)
+    {
+        __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&original_edge_map[i]));
+        __m256i b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&target_edge_map[i]));
+        __m256i c = _mm256_and_si256(a, b);
+        _mm256_storeu_si256(reinterpret_cast<__m256i *>(&intersection_mask[i]), c);
+    }
+
+    for (; i < size; i++)
+    {
+        intersection_mask[i] = original_edge_map[i] & target_edge_map[i];
+    }
+    return intersection_mask;
+}
+
 
 std::array<int, 2> BMP::get_sobel_gradients(int y, int x, const std::vector<std::uint8_t> &data, int width)
 {
@@ -555,52 +642,6 @@ int BMP::calculate_colour_count(const BMP& base, Colour to_compare)
 }
 
 
-std::vector<uint8_t> BMP::calculate_intersection_mask(const BMP &original, const BMP &target)
-{
-    const std::vector<uint8_t> original_edge_map = original.get_blurred_edge_mask();
-    const std::vector<uint8_t> target_edge_map = target.get_blurred_edge_mask();
-
-    int width = std::min(original.get_width(), target.get_width());
-    int height = std::min(original.get_height(), target.get_height());
-
-    std::vector<uint8_t> intersection_mask(width * height, 0);
-    for (int i = 0; i < width * height; i++)
-    {
-        intersection_mask[i] = original_edge_map[i] & target_edge_map[i];
-    }
-    return intersection_mask;
-}
-
-std::vector<uint8_t> BMP::calculate_intersection_mask_simd(const BMP &original, const BMP &target)
-{
-    const std::vector<uint8_t> original_edge_map = original.get_blurred_edge_mask();
-    const std::vector<uint8_t> target_edge_map = target.get_blurred_edge_mask();
-
-    int width = std::min(original.get_width(), target.get_width());
-    int height = std::min(original.get_height(), target.get_height());
-
-    int size = width * height;
-    std::vector<uint8_t> intersection_mask(size, 0);
-
-    int i = 0;
-    // Process 32 bytes at a time using AVX2
-    for (; i + 31 < size; i += 32)
-    {
-        __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&original_edge_map[i]));
-        __m256i b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&target_edge_map[i]));
-        __m256i c = _mm256_and_si256(a, b);
-        _mm256_storeu_si256(reinterpret_cast<__m256i *>(&intersection_mask[i]), c);
-    }
-
-    // Handle the remaining elements
-    for (; i < size; i++)
-    {
-        intersection_mask[i] = original_edge_map[i] & target_edge_map[i];
-    }
-    return intersection_mask;
-}
-
-
 int BMP::get_non_background_pixel_count() const
 {
     if (!m_non_background_pixel_count.has_value()) {
@@ -617,24 +658,24 @@ int BMP::get_background_value() const
     return m_background_value.value();
 }
 
-const std::vector<uint8_t>& BMP::get_blurred_edge_mask() const{
+const std::vector<uint64_t>& BMP::get_blurred_edge_mask() const{
     if (!m_blurred_edge_mask.has_value()) {
         m_blurred_edge_mask = blur_edge_mask();
     }
     return m_blurred_edge_mask.value();
 }
 
-const std::vector<uint8_t>& BMP::get_filtered_vertical_edge_mask() const {
+const std::vector<uint64_t>& BMP::get_filtered_vertical_edge_mask() const {
     if (!m_vertical_edge_mask.has_value()) {
         m_vertical_edge_mask = filter_long_vertical_edge_runs(10);
     }
     return m_vertical_edge_mask.value();
 }
 
-const std::vector<uint8_t> BMP::get_vertical_edge_mask() const {
+const std::vector<uint64_t> BMP::get_vertical_edge_mask() const {
     return get_vertical_edges<245>();
 }
 
-const std::vector<uint8_t> BMP::get_sobel_edge_mask() const {
+const std::vector<uint64_t> BMP::get_sobel_edge_mask() const {
     return sobel_edges<245>();
 }

--- a/src/bmp.cpp
+++ b/src/bmp.cpp
@@ -324,7 +324,7 @@ void BMP::write_side_by_side(const BMP &diff, const BMP &base, const BMP &target
     }
 }
 
-int BMP::get_non_background_pixel_count() const
+int BMP::calculate_non_background_pixel_count() const
 {
     int background_value = get_background_value();
     int non_background_count = 0;
@@ -343,7 +343,7 @@ int BMP::get_non_background_pixel_count() const
     return non_background_count;
 }
 
-int BMP::get_background_value() const
+int BMP::calculate_background_value() const
 {
     int total_gray = 0;
     std::int32_t stride = m_info_header.bit_count / 8;
@@ -362,6 +362,7 @@ void BMP::set_data(std::vector<std::uint8_t> &new_data)
 {
     set_data_internal(new_data);
     invalidate_masks();
+    invalidate_background_value();
 }
 
 void BMP::set_data_internal(std::vector<std::uint8_t> &new_data)
@@ -566,6 +567,22 @@ std::vector<bool> BMP::calculate_intersection_mask(const BMP &original, const BM
         intersection_mask[i] = original_edge_map[i] && target_edge_map[i];
     }
     return intersection_mask;
+}
+
+int BMP::get_non_background_pixel_count() const
+{
+    if (!m_non_background_pixel_count.has_value()) {
+        m_non_background_pixel_count = calculate_non_background_pixel_count();
+    }
+    return m_non_background_pixel_count.value();
+}
+
+int BMP::get_background_value() const
+{
+    if (!m_background_value.has_value()) {
+        m_background_value = calculate_background_value();
+    }
+    return m_background_value.value();
 }
 
 const std::vector<bool>& BMP::get_blurred_edge_mask() const{

--- a/src/bmp.cpp
+++ b/src/bmp.cpp
@@ -566,7 +566,7 @@ std::vector<uint8_t> BMP::calculate_intersection_mask(const BMP &original, const
     std::vector<uint8_t> intersection_mask(width * height, 0);
     for (int i = 0; i < width * height; i++)
     {
-        intersection_mask[i] = original_edge_map[i] && target_edge_map[i];
+        intersection_mask[i] = original_edge_map[i] & target_edge_map[i];
     }
     return intersection_mask;
 }

--- a/src/bmp.cpp
+++ b/src/bmp.cpp
@@ -11,6 +11,7 @@
 #include <bit>
 #include <cmath>
 #include <fstream>
+#include <immintrin.h>
 
 #include "bmp.hpp"
 

--- a/src/bmp.cpp
+++ b/src/bmp.cpp
@@ -361,6 +361,7 @@ int BMP::get_background_value() const
 void BMP::set_data(std::vector<std::uint8_t> &new_data)
 {
     set_data_internal(new_data);
+    invalidate_masks();
 }
 
 void BMP::set_data_internal(std::vector<std::uint8_t> &new_data)
@@ -553,8 +554,8 @@ int BMP::calculate_colour_count(const BMP& base, Colour to_compare)
 
 std::vector<bool> BMP::calculate_intersection_mask(const BMP &original, const BMP &target)
 {
-    std::vector<bool> original_edge_map = original.get_blurred_edge_mask();
-    std::vector<bool> target_edge_map = target.get_blurred_edge_mask();
+    const std::vector<bool> original_edge_map = original.get_blurred_edge_mask();
+    const std::vector<bool> target_edge_map = target.get_blurred_edge_mask();
 
     int width = std::min(original.get_width(), target.get_width());
     int height = std::min(original.get_height(), target.get_height());
@@ -567,12 +568,18 @@ std::vector<bool> BMP::calculate_intersection_mask(const BMP &original, const BM
     return intersection_mask;
 }
 
-const std::vector<bool> BMP::get_blurred_edge_mask() const {
-    return blur_edge_mask();
+const std::vector<bool>& BMP::get_blurred_edge_mask() const{
+    if (!m_blurred_edge_mask.has_value()) {
+        m_blurred_edge_mask = blur_edge_mask();
+    }
+    return m_blurred_edge_mask.value();
 }
 
-const std::vector<bool> BMP::get_filtered_vertical_edge_mask() const {
-    return filter_long_vertical_edge_runs(10);
+const std::vector<bool>& BMP::get_filtered_vertical_edge_mask() const {
+    if (!m_vertical_edge_mask.has_value()) {
+        m_vertical_edge_mask = filter_long_vertical_edge_runs(10);
+    }
+    return m_vertical_edge_mask.value();
 }
 
 const std::vector<bool> BMP::get_vertical_edge_mask() const {

--- a/src/bmp.cpp
+++ b/src/bmp.cpp
@@ -151,19 +151,12 @@ void BMP::write(std::string filename)
     }
 }
 
-void BMP::write_with_filter(const BMP &base, std::string filename, std::vector<uint64_t> filter_mask)
+void BMP::write_with_filter(const BMP &base, std::string filename, std::vector<uint8_t> filter_mask)
 {
     const int base_width = base.get_width();
     const int base_height = base.get_height();
     BMP copy(base);
     std::vector<uint8_t> copy_data = base.get_data();
-
-    auto get_bit = [&](const std::vector<uint64_t> &mask, int pixel_index) {
-        int array_index = pixel_index / 64;
-        int bit = pixel_index % 64;
-        return (mask[array_index] >> bit) & 1;
-    };
-
     for (int y = 0; y < base_height; y++)
     {
         for (int x = 0; x < base_width; x++)
@@ -171,7 +164,7 @@ void BMP::write_with_filter(const BMP &base, std::string filename, std::vector<u
             int index = y * base_width + x;
             int byte_index = index * pixel_stride;
 
-            if (get_bit(filter_mask, index))
+            if (filter_mask[index])
             {
                 copy_data[byte_index + 0] = 0;
                 copy_data[byte_index + 1] = 0;
@@ -383,24 +376,37 @@ void BMP::set_data_internal(std::vector<std::uint8_t> &new_data)
     m_data = new_data;
 }
 
+std::vector<uint8_t> BMP::blur_edge_mask() const
+{
+    std::vector<uint8_t> edge_map = sobel_edges<245>();
+    std::int32_t width = m_info_header.width;
+    std::int32_t height = m_info_header.height;
+    std::vector<uint8_t> blurred_mask(width * height, 0);
+
+    for (int y = 1; y < height - 1; y++)
+    {
+        for (int x = 1; x < width - 1; x++)
+        {
+            int index = y * width + x;
+
+            // If the current pixel is not an edge, skip it
+            if (!edge_map[index])
+                continue;
+
+            blur_pixels<2>(x, y, width, height, blurred_mask);
+        }
+    }
+    return blurred_mask;
+}
 
 template <int Threshold>
-std::vector<uint64_t> BMP::sobel_edges() const
+std::vector<uint8_t> BMP::sobel_edges() const
 {
     std::int32_t width = m_info_header.width;
     std::int32_t height = m_info_header.height;
     const std::vector<std::uint8_t> &data = m_data;
 
-    int n_pixels = width * height;
-    int size = (n_pixels + 63) / 64;
-
-    std::vector<uint64_t> result(size, 0);
-
-    auto set_bit = [&](int pixel_index) {
-        int array_index = pixel_index / 64;
-        int bit = pixel_index % 64;
-        result[array_index] |= uint64_t(1) << bit;
-    };
+    std::vector<uint8_t> result(width * height, 0);
 
     // Loop through each pixel in the image, skipping the edges to avoid out-of-bounds access
     for (int y = 1; y < height - 1; y++)
@@ -412,99 +418,18 @@ std::vector<uint64_t> BMP::sobel_edges() const
             // Calculate gradient magnitude (clamped to 255)
             int magnitude = std::min(255, static_cast<int>(std::sqrt(g_x * g_x + g_y * g_y)));
 
-            if (magnitude >= Threshold) {
-                set_bit(y * width + x);
-            }
+            result[y * width + x] = (magnitude >= Threshold) ? 1 : 0;
         }
     }
     return result;
 }
 
-template <int Threshold>
-std::vector<uint64_t> BMP::get_vertical_edges() const
+std::vector<uint8_t> BMP::filter_long_vertical_edge_runs(int min_run_length) const
 {
-    std::int32_t width = m_info_header.width;
-    std::int32_t height = m_info_header.height;
-    const std::vector<std::uint8_t> &data = m_data;
-
-    int n_pixels = width * height;
-    int size = (n_pixels + 63) / 64;
-    std::vector<uint64_t> result(size, 0);
-
-    auto set_bit = [&](int pixel_index) {
-        int array_index = pixel_index / 64;
-        int bit = pixel_index % 64;
-        result[array_index] |= uint64_t(1) << bit;
-    };
-
-    for (int y = 1; y < height - 1; y++)
-    {
-        for (int x = 1; x < width - 1; x++)
-        {
-            auto [g_x, g_y] = get_sobel_gradients(y, x, data, width);
-
-            int abs_gx = std::abs(g_x);
-
-            if (abs_gx >= Threshold) {
-                set_bit(y * width + x);
-            }
-        }
-    }
-    return result;
-}
-
-std::vector<uint64_t> BMP::blur_edge_mask() const
-{
-    std::vector<uint64_t> edge_map = sobel_edges<245>();
-
-    std::int32_t width = m_info_header.width;
-    std::int32_t height = m_info_header.height;
-
-    int n_pixels = width * height;
-    int size = (n_pixels + 63) / 64;
-    std::vector<uint64_t> blurred_mask(size, 0);
-
-    auto get_bit = [&](const std::vector<uint64_t> &mask, int pixel_index) {
-        int array_index = pixel_index / 64;
-        int bit = pixel_index % 64;
-        return (mask[array_index] >> bit) & 1;
-    };
-
-    for (int y = 1; y < height - 1; y++)
-    {
-        for (int x = 1; x < width - 1; x++)
-        {
-            int index = y * width + x;
-            if (get_bit(edge_map, index) == 0)
-                continue;
-
-            blur_pixels<2>(x, y, width, height, blurred_mask);
-        }
-    }
-    return blurred_mask;
-}
-
-std::vector<uint64_t> BMP::filter_long_vertical_edge_runs(int min_run_length) const
-{
-    std::vector<uint64_t> vertical_edges = get_vertical_edges<245>();
+    std::vector<uint8_t> vertical_edges = get_vertical_edges<245>();
+    std::vector<uint8_t> result(vertical_edges.size(), 0);
     int width = m_info_header.width;
     int height = m_info_header.height;
-
-    int n_pixels = width * height;
-    int size = (n_pixels + 63) / 64;
-    std::vector<uint64_t> result(size, 0);
-
-    auto get_bit = [&](const std::vector<uint64_t> &mask, int pixel_index) {
-        int array_index = pixel_index / 64;
-        int bit = pixel_index % 64;
-        return (mask[array_index] >> bit) & 1;
-    };
-
-    auto set_bit = [&](int pixel_index) {
-        int array_index = pixel_index / 64;
-        int bit = pixel_index % 64;
-        result[array_index] |= uint64_t(1) << bit;
-    };
 
     for (int x = 0; x < width; x++)
     {
@@ -514,7 +439,7 @@ std::vector<uint64_t> BMP::filter_long_vertical_edge_runs(int min_run_length) co
         for (int y = 0; y < height; y++)
         {
             int index = y * width + x;
-            if (get_bit(vertical_edges, index))
+            if (vertical_edges[index])
             {
                 if (run_start == -1)
                 {
@@ -529,7 +454,7 @@ std::vector<uint64_t> BMP::filter_long_vertical_edge_runs(int min_run_length) co
                     // copy the run
                     for (int i = run_start; i < run_start + run_length; i++)
                     {
-                        set_bit(i * width + x);
+                        result[i * width + x] = 1;
                     }
                 }
                 run_start = -1;
@@ -540,15 +465,32 @@ std::vector<uint64_t> BMP::filter_long_vertical_edge_runs(int min_run_length) co
     return result;
 }
 
-template <int Radius>
-void BMP::blur_pixels(int x, int y, int width, int height, std::vector<uint64_t> &mask)
+template <int Threshold>
+std::vector<uint8_t> BMP::get_vertical_edges() const
 {
-    auto set_bit = [&](int pixel_index) {
-        int array_index = pixel_index / 64;
-        int bit = pixel_index % 64;
-        mask[array_index] |= uint64_t(1) << bit;
-    };
+    std::int32_t width = m_info_header.width;
+    std::int32_t height = m_info_header.height;
+    const std::vector<std::uint8_t> &data = m_data;
 
+    std::vector<uint8_t> result(width * height, 0);
+
+    for (int y = 1; y < height - 1; y++)
+    {
+        for (int x = 1; x < width - 1; x++)
+        {
+            auto [g_x, g_y] = get_sobel_gradients(y, x, data, width);
+
+            int abs_gx = std::abs(g_x);
+
+            result[y * width + x] = (abs_gx >= Threshold) ? 1 : 0;
+        }
+    }
+    return result;
+}
+
+template <int Radius>
+void BMP::blur_pixels(int x, int y, int width, int height, std::vector<uint8_t> &mask)
+{
     for (int dy = -Radius; dy <= Radius; dy++)
     {
         for (int dx = -Radius; dx <= Radius; dx++)
@@ -559,40 +501,11 @@ void BMP::blur_pixels(int x, int y, int width, int height, std::vector<uint64_t>
             // Check if the new coordinates are within bounds
             if (new_x >= 0 && new_x < width && new_y >= 0 && new_y < height)
             {
-                set_bit(new_y * width + new_x);
+                mask[new_y * width + new_x] = 1;
             }
         }
     }
 }
-
-std::vector<uint64_t> BMP::calculate_intersection_mask_simd(const BMP &original, const BMP &target)
-{
-    const std::vector<uint64_t> original_edge_map = original.get_blurred_edge_mask();
-    const std::vector<uint64_t> target_edge_map = target.get_blurred_edge_mask();
-
-    int width = std::min(original.get_width(), target.get_width());
-    int height = std::min(original.get_height(), target.get_height());
-
-    int n_bits = width * height;
-    int size = (n_bits + 63) / 64;
-    std::vector<uint64_t> intersection_mask(size, 0);
-
-    int i = 0;
-    for (; i + 3 < size; i += 4)
-    {
-        __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&original_edge_map[i]));
-        __m256i b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&target_edge_map[i]));
-        __m256i c = _mm256_and_si256(a, b);
-        _mm256_storeu_si256(reinterpret_cast<__m256i *>(&intersection_mask[i]), c);
-    }
-
-    for (; i < size; i++)
-    {
-        intersection_mask[i] = original_edge_map[i] & target_edge_map[i];
-    }
-    return intersection_mask;
-}
-
 
 std::array<int, 2> BMP::get_sobel_gradients(int y, int x, const std::vector<std::uint8_t> &data, int width)
 {
@@ -642,6 +555,52 @@ int BMP::calculate_colour_count(const BMP& base, Colour to_compare)
 }
 
 
+std::vector<uint8_t> BMP::calculate_intersection_mask(const BMP &original, const BMP &target)
+{
+    const std::vector<uint8_t> original_edge_map = original.get_blurred_edge_mask();
+    const std::vector<uint8_t> target_edge_map = target.get_blurred_edge_mask();
+
+    int width = std::min(original.get_width(), target.get_width());
+    int height = std::min(original.get_height(), target.get_height());
+
+    std::vector<uint8_t> intersection_mask(width * height, 0);
+    for (int i = 0; i < width * height; i++)
+    {
+        intersection_mask[i] = original_edge_map[i] & target_edge_map[i];
+    }
+    return intersection_mask;
+}
+
+std::vector<uint8_t> BMP::calculate_intersection_mask_simd(const BMP &original, const BMP &target)
+{
+    const std::vector<uint8_t> original_edge_map = original.get_blurred_edge_mask();
+    const std::vector<uint8_t> target_edge_map = target.get_blurred_edge_mask();
+
+    int width = std::min(original.get_width(), target.get_width());
+    int height = std::min(original.get_height(), target.get_height());
+
+    int size = width * height;
+    std::vector<uint8_t> intersection_mask(size, 0);
+
+    int i = 0;
+    // Process 32 bytes at a time using AVX2
+    for (; i + 31 < size; i += 32)
+    {
+        __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&original_edge_map[i]));
+        __m256i b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&target_edge_map[i]));
+        __m256i c = _mm256_and_si256(a, b);
+        _mm256_storeu_si256(reinterpret_cast<__m256i *>(&intersection_mask[i]), c);
+    }
+
+    // Handle the remaining elements
+    for (; i < size; i++)
+    {
+        intersection_mask[i] = original_edge_map[i] & target_edge_map[i];
+    }
+    return intersection_mask;
+}
+
+
 int BMP::get_non_background_pixel_count() const
 {
     if (!m_non_background_pixel_count.has_value()) {
@@ -658,24 +617,24 @@ int BMP::get_background_value() const
     return m_background_value.value();
 }
 
-const std::vector<uint64_t>& BMP::get_blurred_edge_mask() const{
+const std::vector<uint8_t>& BMP::get_blurred_edge_mask() const{
     if (!m_blurred_edge_mask.has_value()) {
         m_blurred_edge_mask = blur_edge_mask();
     }
     return m_blurred_edge_mask.value();
 }
 
-const std::vector<uint64_t>& BMP::get_filtered_vertical_edge_mask() const {
+const std::vector<uint8_t>& BMP::get_filtered_vertical_edge_mask() const {
     if (!m_vertical_edge_mask.has_value()) {
         m_vertical_edge_mask = filter_long_vertical_edge_runs(10);
     }
     return m_vertical_edge_mask.value();
 }
 
-const std::vector<uint64_t> BMP::get_vertical_edge_mask() const {
+const std::vector<uint8_t> BMP::get_vertical_edge_mask() const {
     return get_vertical_edges<245>();
 }
 
-const std::vector<uint64_t> BMP::get_sobel_edge_mask() const {
+const std::vector<uint8_t> BMP::get_sobel_edge_mask() const {
     return sobel_edges<245>();
 }

--- a/src/bmp.hpp
+++ b/src/bmp.hpp
@@ -57,18 +57,18 @@ public:
     static BMP stamp_name(const BMP &base, const BMP &stamp);
     static void write_side_by_side(const BMP &diff, const BMP &base, const BMP &target, std::string stamp_location, std::string filename);
     static int calculate_colour_count(const BMP& base, Colour to_compare);
-    static void write_with_filter(const BMP &base, std::string filename, std::vector<uint64_t> filter_mask);
-    static std::vector<uint64_t> calculate_intersection_mask(const BMP &original, const BMP &target);
-    static std::vector<uint64_t> calculate_intersection_mask_simd(const BMP &original, const BMP &target);
+    static void write_with_filter(const BMP &base, std::string filename, std::vector<uint8_t> filter_mask);
+    static std::vector<uint8_t> calculate_intersection_mask(const BMP &original, const BMP &target);
+    static std::vector<uint8_t> calculate_intersection_mask_simd(const BMP &original, const BMP &target);
 
 
     const std::vector<std::uint8_t> &get_data() const { return m_data; }
 
     // simd versions return uint8_t vectors with 0 or 1 values
-    const std::vector<uint64_t> get_vertical_edge_mask() const;
-    const std::vector<uint64_t> get_sobel_edge_mask() const;
-    const std::vector<uint64_t>& get_filtered_vertical_edge_mask() const;
-    const std::vector<uint64_t>& get_blurred_edge_mask() const;
+    const std::vector<uint8_t> get_vertical_edge_mask() const;
+    const std::vector<uint8_t> get_sobel_edge_mask() const;
+    const std::vector<uint8_t>& get_filtered_vertical_edge_mask() const;
+    const std::vector<uint8_t>& get_blurred_edge_mask() const;
 
     int get_width() const { return m_info_header.width; }
     int get_height() const { return m_info_header.height; }
@@ -102,14 +102,14 @@ private:
     void set_data_internal(std::vector<std::uint8_t> &new_data);
 
     template <int Threshold>
-    std::vector<uint64_t> sobel_edges() const;
+    std::vector<uint8_t> sobel_edges() const;
     template <int Threshold> // compile-time constant
-    std::vector<uint64_t> get_vertical_edges() const;
+    std::vector<uint8_t> get_vertical_edges() const;
     template <int Radius> // compile-time constant
-    static void blur_pixels(int x, int y, int width, int height, std::vector<uint64_t> &mask);
+    static void blur_pixels(int x, int y, int width, int height, std::vector<uint8_t> &mask);
 
-    std::vector<uint64_t> blur_edge_mask() const;
-    std::vector<uint64_t> filter_long_vertical_edge_runs(int min_run_length)const ;
+    std::vector<uint8_t> blur_edge_mask() const;
+    std::vector<uint8_t> filter_long_vertical_edge_runs(int min_run_length)const ;
     static std::array<int, 2> get_sobel_gradients(int y, int x, const std::vector<std::uint8_t> &data, int width);
 
     int calculate_background_value() const;
@@ -124,8 +124,8 @@ private:
     int m_blue_count = 0;
     int m_green_count = 0;
 
-    mutable std::optional<std::vector<uint64_t>> m_blurred_edge_mask;
-    mutable std::optional<std::vector<uint64_t>> m_vertical_edge_mask;
+    mutable std::optional<std::vector<uint8_t>> m_blurred_edge_mask;
+    mutable std::optional<std::vector<uint8_t>> m_vertical_edge_mask;
     mutable std::optional<int> m_background_value;
     mutable std::optional<int> m_non_background_pixel_count;
 };

--- a/src/bmp.hpp
+++ b/src/bmp.hpp
@@ -17,7 +17,6 @@
 #include <iostream>
 #include <optional>
 #include <vector>
-#include "immintrin.h"
 
 #include "pixel.hpp"
 

--- a/src/bmp.hpp
+++ b/src/bmp.hpp
@@ -57,11 +57,12 @@ public:
     static void write_side_by_side(const BMP &diff, const BMP &base, const BMP &target, std::string stamp_location, std::string filename);
     static int calculate_colour_count(const BMP& base, Colour to_compare);
     static void write_with_filter(const BMP &base, std::string filename, std::vector<bool> filter_mask);
+    static std::vector<bool> calculate_intersection_mask(const BMP &original, const BMP &target);
 
     const std::vector<std::uint8_t> &get_data() const { return m_data; }
-    const std::vector<bool>& get_blurred_edge_mask() const;
+    const std::vector<bool> get_blurred_edge_mask() const;
     const std::vector<bool> get_vertical_edge_mask() const;
-    const std::vector<bool>& get_filtered_vertical_edge_mask() const;
+    const std::vector<bool> get_filtered_vertical_edge_mask() const;
     const std::vector<bool> get_sobel_edge_mask() const;
     int get_width() const { return m_info_header.width; }
     int get_height() const { return m_info_header.height; }
@@ -105,7 +106,5 @@ private:
     int m_dark_yellow_count = 0;
     int m_blue_count = 0;
     int m_green_count = 0;
-    std::vector<bool> m_blurred_edge_mask;
-    std::vector<bool> m_filtered_edge_mask;
 };
 #endif

--- a/src/bmp.hpp
+++ b/src/bmp.hpp
@@ -86,6 +86,10 @@ public:
         m_blurred_edge_mask.reset();
         m_vertical_edge_mask.reset();
     }
+    void invalidate_background_value() {
+        m_background_value.reset();
+        m_non_background_pixel_count.reset();
+    }
 
 private:
     void read(std::string filename);
@@ -104,6 +108,9 @@ private:
     std::vector<bool> filter_long_vertical_edge_runs(int min_run_length)const ;
     static std::array<int, 2> get_sobel_gradients(int y, int x, const std::vector<std::uint8_t> &data, int width);
 
+    int calculate_background_value() const;
+    int calculate_non_background_pixel_count() const;
+
     BMPFileHeader m_file_header;
     BMPInfoHeader m_info_header;
     std::vector<std::uint8_t> m_data;
@@ -115,5 +122,7 @@ private:
 
     mutable std::optional<std::vector<bool>> m_blurred_edge_mask;
     mutable std::optional<std::vector<bool>> m_vertical_edge_mask;
+    mutable std::optional<int> m_background_value;
+    mutable std::optional<int> m_non_background_pixel_count;
 };
 #endif

--- a/src/bmp.hpp
+++ b/src/bmp.hpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <optional>
 #include <vector>
+#include "immintrin.h"
 
 #include "pixel.hpp"
 
@@ -57,14 +58,18 @@ public:
     static BMP stamp_name(const BMP &base, const BMP &stamp);
     static void write_side_by_side(const BMP &diff, const BMP &base, const BMP &target, std::string stamp_location, std::string filename);
     static int calculate_colour_count(const BMP& base, Colour to_compare);
-    static void write_with_filter(const BMP &base, std::string filename, std::vector<bool> filter_mask);
-    static std::vector<bool> calculate_intersection_mask(const BMP &original, const BMP &target);
+    static void write_with_filter(const BMP &base, std::string filename, std::vector<uint8_t> filter_mask);
+    static std::vector<uint8_t> calculate_intersection_mask(const BMP &original, const BMP &target);
+    static std::vector<uint8_t> calculate_intersection_mask_simd(const BMP &original, const BMP &target);
+
 
     const std::vector<std::uint8_t> &get_data() const { return m_data; }
-    const std::vector<bool> get_vertical_edge_mask() const;
-    const std::vector<bool> get_sobel_edge_mask() const;
-    const std::vector<bool>& get_filtered_vertical_edge_mask() const;
-    const std::vector<bool>& get_blurred_edge_mask() const;
+
+    // simd versions return uint8_t vectors with 0 or 1 values
+    const std::vector<uint8_t> get_vertical_edge_mask() const;
+    const std::vector<uint8_t> get_sobel_edge_mask() const;
+    const std::vector<uint8_t>& get_filtered_vertical_edge_mask() const;
+    const std::vector<uint8_t>& get_blurred_edge_mask() const;
 
     int get_width() const { return m_info_header.width; }
     int get_height() const { return m_info_header.height; }
@@ -98,14 +103,14 @@ private:
     void set_data_internal(std::vector<std::uint8_t> &new_data);
 
     template <int Threshold>
-    std::vector<bool> sobel_edges() const;
+    std::vector<uint8_t> sobel_edges() const;
     template <int Threshold> // compile-time constant
-    std::vector<bool> get_vertical_edges() const;
+    std::vector<uint8_t> get_vertical_edges() const;
     template <int Radius> // compile-time constant
-    static void blur_pixels(int x, int y, int width, int height, std::vector<bool> &mask);
+    static void blur_pixels(int x, int y, int width, int height, std::vector<uint8_t> &mask);
 
-    std::vector<bool> blur_edge_mask() const;
-    std::vector<bool> filter_long_vertical_edge_runs(int min_run_length)const ;
+    std::vector<uint8_t> blur_edge_mask() const;
+    std::vector<uint8_t> filter_long_vertical_edge_runs(int min_run_length)const ;
     static std::array<int, 2> get_sobel_gradients(int y, int x, const std::vector<std::uint8_t> &data, int width);
 
     int calculate_background_value() const;
@@ -120,8 +125,8 @@ private:
     int m_blue_count = 0;
     int m_green_count = 0;
 
-    mutable std::optional<std::vector<bool>> m_blurred_edge_mask;
-    mutable std::optional<std::vector<bool>> m_vertical_edge_mask;
+    mutable std::optional<std::vector<uint8_t>> m_blurred_edge_mask;
+    mutable std::optional<std::vector<uint8_t>> m_vertical_edge_mask;
     mutable std::optional<int> m_background_value;
     mutable std::optional<int> m_non_background_pixel_count;
 };

--- a/src/bmp.hpp
+++ b/src/bmp.hpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
+#include <optional>
 #include <vector>
 
 #include "pixel.hpp"
@@ -60,10 +61,11 @@ public:
     static std::vector<bool> calculate_intersection_mask(const BMP &original, const BMP &target);
 
     const std::vector<std::uint8_t> &get_data() const { return m_data; }
-    const std::vector<bool> get_blurred_edge_mask() const;
     const std::vector<bool> get_vertical_edge_mask() const;
-    const std::vector<bool> get_filtered_vertical_edge_mask() const;
     const std::vector<bool> get_sobel_edge_mask() const;
+    const std::vector<bool>& get_filtered_vertical_edge_mask() const;
+    const std::vector<bool>& get_blurred_edge_mask() const;
+
     int get_width() const { return m_info_header.width; }
     int get_height() const { return m_info_header.height; }
     int get_red_count() const { return m_red_count; }
@@ -80,6 +82,10 @@ public:
     void increment_blue_count(int new_blue) { m_blue_count += new_blue; }
     void increment_green_count(int new_green) { m_green_count += new_green; }
     void set_data(std::vector<std::uint8_t> &new_data);
+    void invalidate_masks() {
+        m_blurred_edge_mask.reset();
+        m_vertical_edge_mask.reset();
+    }
 
 private:
     void read(std::string filename);
@@ -106,5 +112,8 @@ private:
     int m_dark_yellow_count = 0;
     int m_blue_count = 0;
     int m_green_count = 0;
+
+    mutable std::optional<std::vector<bool>> m_blurred_edge_mask;
+    mutable std::optional<std::vector<bool>> m_vertical_edge_mask;
 };
 #endif

--- a/src/bmp.hpp
+++ b/src/bmp.hpp
@@ -57,18 +57,18 @@ public:
     static BMP stamp_name(const BMP &base, const BMP &stamp);
     static void write_side_by_side(const BMP &diff, const BMP &base, const BMP &target, std::string stamp_location, std::string filename);
     static int calculate_colour_count(const BMP& base, Colour to_compare);
-    static void write_with_filter(const BMP &base, std::string filename, std::vector<uint8_t> filter_mask);
-    static std::vector<uint8_t> calculate_intersection_mask(const BMP &original, const BMP &target);
-    static std::vector<uint8_t> calculate_intersection_mask_simd(const BMP &original, const BMP &target);
+    static void write_with_filter(const BMP &base, std::string filename, std::vector<uint64_t> filter_mask);
+    static std::vector<uint64_t> calculate_intersection_mask(const BMP &original, const BMP &target);
+    static std::vector<uint64_t> calculate_intersection_mask_simd(const BMP &original, const BMP &target);
 
 
     const std::vector<std::uint8_t> &get_data() const { return m_data; }
 
     // simd versions return uint8_t vectors with 0 or 1 values
-    const std::vector<uint8_t> get_vertical_edge_mask() const;
-    const std::vector<uint8_t> get_sobel_edge_mask() const;
-    const std::vector<uint8_t>& get_filtered_vertical_edge_mask() const;
-    const std::vector<uint8_t>& get_blurred_edge_mask() const;
+    const std::vector<uint64_t> get_vertical_edge_mask() const;
+    const std::vector<uint64_t> get_sobel_edge_mask() const;
+    const std::vector<uint64_t>& get_filtered_vertical_edge_mask() const;
+    const std::vector<uint64_t>& get_blurred_edge_mask() const;
 
     int get_width() const { return m_info_header.width; }
     int get_height() const { return m_info_header.height; }
@@ -102,14 +102,14 @@ private:
     void set_data_internal(std::vector<std::uint8_t> &new_data);
 
     template <int Threshold>
-    std::vector<uint8_t> sobel_edges() const;
+    std::vector<uint64_t> sobel_edges() const;
     template <int Threshold> // compile-time constant
-    std::vector<uint8_t> get_vertical_edges() const;
+    std::vector<uint64_t> get_vertical_edges() const;
     template <int Radius> // compile-time constant
-    static void blur_pixels(int x, int y, int width, int height, std::vector<uint8_t> &mask);
+    static void blur_pixels(int x, int y, int width, int height, std::vector<uint64_t> &mask);
 
-    std::vector<uint8_t> blur_edge_mask() const;
-    std::vector<uint8_t> filter_long_vertical_edge_runs(int min_run_length)const ;
+    std::vector<uint64_t> blur_edge_mask() const;
+    std::vector<uint64_t> filter_long_vertical_edge_runs(int min_run_length)const ;
     static std::array<int, 2> get_sobel_gradients(int y, int x, const std::vector<std::uint8_t> &data, int width);
 
     int calculate_background_value() const;
@@ -124,8 +124,8 @@ private:
     int m_blue_count = 0;
     int m_green_count = 0;
 
-    mutable std::optional<std::vector<uint8_t>> m_blurred_edge_mask;
-    mutable std::optional<std::vector<uint8_t>> m_vertical_edge_mask;
+    mutable std::optional<std::vector<uint64_t>> m_blurred_edge_mask;
+    mutable std::optional<std::vector<uint64_t>> m_vertical_edge_mask;
     mutable std::optional<int> m_background_value;
     mutable std::optional<int> m_non_background_pixel_count;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,10 +179,10 @@ ParsedArguments parse_arguments(int argc, char *argv[], int pdf_count = 3)
     return args;
 }
 
-BMP diff(PixelBasher &pixel_basher, BMP &base, BMP &target,
+BMP diff(BMP &base, BMP &target,
         bool allow_minor_diffs)
 {
-    BMP diff = pixel_basher.compare_bmps(base, target, allow_minor_diffs);
+    BMP diff = pixelbasher::compare_bmps(base, target, allow_minor_diffs);
     return diff;
 }
 
@@ -191,7 +191,6 @@ int main(int argc, char *argv[])
     try
     {
         ParsedArguments args = parse_arguments(argc, argv);
-        PixelBasher pixel_basher;
         const std::string csv_filename = "diff-pdf-" + args.extension;
 
         size_t num_pages = args.ms_orig_images.size();
@@ -211,8 +210,8 @@ int main(int argc, char *argv[])
             BMP lo_previous;
             BMP ms_conv_previous;
 
-            BMP lo_diff = diff(pixel_basher, base, lo, args.enable_minor_differences);
-            BMP ms_conv_diff = diff(pixel_basher, base, ms_conv, args.enable_minor_differences);
+            BMP lo_diff = diff(base, lo, args.enable_minor_differences);
+            BMP ms_conv_diff = diff(base, ms_conv, args.enable_minor_differences);
 
             BMP lo_previous_diff;
             BMP ms_conv_previous_diff;
@@ -224,9 +223,9 @@ int main(int argc, char *argv[])
             if (args.lo_previous)
             {
                 lo_previous = args.lo_previous_images[i];
-                lo_previous_diff = diff(pixel_basher, base, lo_previous, args.enable_minor_differences);
+                lo_previous_diff = diff(base, lo_previous, args.enable_minor_differences);
 
-                lo_compare = pixel_basher.compare_regressions(base, lo_diff, lo_previous_diff);
+                lo_compare = pixelbasher::compare_regressions(base, lo_diff, lo_previous_diff);
                 if (args.no_save_overlay)
                 {
                     if (lo_diff.get_red_count() > lo_previous_diff.get_red_count())
@@ -239,9 +238,9 @@ int main(int argc, char *argv[])
             if (args.ms_previous)
             {
                 ms_conv_previous = args.ms_conv_previous_images[i];
-                ms_conv_previous_diff = diff(pixel_basher, base, ms_conv_previous, args.enable_minor_differences);
+                ms_conv_previous_diff = diff(base, ms_conv_previous, args.enable_minor_differences);
 
-                ms_conv_compare = pixel_basher.compare_regressions(base, ms_conv_diff, ms_conv_previous_diff);
+                ms_conv_compare = pixelbasher::compare_regressions(base, ms_conv_diff, ms_conv_previous_diff);
                 if (args.no_save_overlay)
                 {
                     if (ms_conv_diff.get_red_count() > ms_conv_previous_diff.get_red_count())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,12 +180,9 @@ ParsedArguments parse_arguments(int argc, char *argv[], int pdf_count = 3)
 }
 
 BMP diff(PixelBasher &pixel_basher, BMP &base, BMP &target,
-        const std::vector<bool> &original_vertical_edges,
-        const std::vector<bool> &target_vertical_edges,
-        const std::vector<bool> &intersection_mask,
         bool allow_minor_diffs)
 {
-    BMP diff = pixel_basher.compare_bmps(base, target, original_vertical_edges, target_vertical_edges, intersection_mask, allow_minor_diffs);
+    BMP diff = pixel_basher.compare_bmps(base, target, allow_minor_diffs);
     return diff;
 }
 
@@ -214,16 +211,8 @@ int main(int argc, char *argv[])
             BMP lo_previous;
             BMP ms_conv_previous;
 
-            // calculate edge masks once per image to save time
-            std::vector<bool> base_vertical_edges = base.get_filtered_vertical_edge_mask();
-            std::vector<bool> lo_vertical_edges = lo.get_filtered_vertical_edge_mask();
-            std::vector<bool> ms_conv_vertical_edges = ms_conv.get_filtered_vertical_edge_mask();
-
-            std::vector<bool> lo_intersection_mask = BMP::calculate_intersection_mask(base, lo);
-            std::vector<bool> ms_conv_intersection_mask = BMP::calculate_intersection_mask(base, ms_conv);
-
-            BMP lo_diff = diff(pixel_basher, base, lo, base_vertical_edges, lo_vertical_edges, lo_intersection_mask, args.enable_minor_differences);
-            BMP ms_conv_diff = diff(pixel_basher, base, ms_conv, base_vertical_edges, ms_conv_vertical_edges, ms_conv_intersection_mask, args.enable_minor_differences);
+            BMP lo_diff = diff(pixel_basher, base, lo, args.enable_minor_differences);
+            BMP ms_conv_diff = diff(pixel_basher, base, ms_conv, args.enable_minor_differences);
 
             BMP lo_previous_diff;
             BMP ms_conv_previous_diff;
@@ -235,9 +224,7 @@ int main(int argc, char *argv[])
             if (args.lo_previous)
             {
                 lo_previous = args.lo_previous_images[i];
-                std::vector<bool> lo_previous_vertical_edges = lo_previous.get_filtered_vertical_edge_mask();
-                std::vector<bool> lo_previous_intersection_mask = BMP::calculate_intersection_mask(base, lo_previous);
-                lo_previous_diff = diff(pixel_basher, base, lo_previous, base_vertical_edges, lo_previous_vertical_edges, lo_previous_intersection_mask, args.enable_minor_differences);
+                lo_previous_diff = diff(pixel_basher, base, lo_previous, args.enable_minor_differences);
 
                 lo_compare = pixel_basher.compare_regressions(base, lo_diff, lo_previous_diff);
                 if (args.no_save_overlay)
@@ -252,9 +239,7 @@ int main(int argc, char *argv[])
             if (args.ms_previous)
             {
                 ms_conv_previous = args.ms_conv_previous_images[i];
-                std::vector<bool> ms_conv_previous_vertical_edges = ms_conv_previous.get_filtered_vertical_edge_mask();
-                std::vector<bool> ms_conv_previous_intersection_mask = BMP::calculate_intersection_mask(base, ms_conv_previous);
-                ms_conv_previous_diff = diff(pixel_basher, base, ms_conv_previous, base_vertical_edges, ms_conv_previous_vertical_edges, ms_conv_previous_intersection_mask, args.enable_minor_differences);
+                ms_conv_previous_diff = diff(pixel_basher, base, ms_conv_previous, args.enable_minor_differences);
 
                 ms_conv_compare = pixel_basher.compare_regressions(base, ms_conv_diff, ms_conv_previous_diff);
                 if (args.no_save_overlay)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,9 +179,13 @@ ParsedArguments parse_arguments(int argc, char *argv[], int pdf_count = 3)
     return args;
 }
 
-BMP diff(PixelBasher &pixel_basher, BMP &base, BMP &target, bool allow_minor_diffs)
+BMP diff(PixelBasher &pixel_basher, BMP &base, BMP &target,
+        const std::vector<bool> &original_vertical_edges,
+        const std::vector<bool> &target_vertical_edges,
+        const std::vector<bool> &intersection_mask,
+        bool allow_minor_diffs)
 {
-    BMP diff = pixel_basher.compare_bmps(base, target, allow_minor_diffs);
+    BMP diff = pixel_basher.compare_bmps(base, target, original_vertical_edges, target_vertical_edges, intersection_mask, allow_minor_diffs);
     return diff;
 }
 
@@ -210,8 +214,16 @@ int main(int argc, char *argv[])
             BMP lo_previous;
             BMP ms_conv_previous;
 
-            BMP lo_diff = diff(pixel_basher, base, lo, args.enable_minor_differences);
-            BMP ms_conv_diff = diff(pixel_basher, base, ms_conv, args.enable_minor_differences);
+            // calculate edge masks once per image to save time
+            std::vector<bool> base_vertical_edges = base.get_filtered_vertical_edge_mask();
+            std::vector<bool> lo_vertical_edges = lo.get_filtered_vertical_edge_mask();
+            std::vector<bool> ms_conv_vertical_edges = ms_conv.get_filtered_vertical_edge_mask();
+
+            std::vector<bool> lo_intersection_mask = BMP::calculate_intersection_mask(base, lo);
+            std::vector<bool> ms_conv_intersection_mask = BMP::calculate_intersection_mask(base, ms_conv);
+
+            BMP lo_diff = diff(pixel_basher, base, lo, base_vertical_edges, lo_vertical_edges, lo_intersection_mask, args.enable_minor_differences);
+            BMP ms_conv_diff = diff(pixel_basher, base, ms_conv, base_vertical_edges, ms_conv_vertical_edges, ms_conv_intersection_mask, args.enable_minor_differences);
 
             BMP lo_previous_diff;
             BMP ms_conv_previous_diff;
@@ -223,7 +235,9 @@ int main(int argc, char *argv[])
             if (args.lo_previous)
             {
                 lo_previous = args.lo_previous_images[i];
-                lo_previous_diff = diff(pixel_basher, base, lo_previous, args.enable_minor_differences);
+                std::vector<bool> lo_previous_vertical_edges = lo_previous.get_filtered_vertical_edge_mask();
+                std::vector<bool> lo_previous_intersection_mask = BMP::calculate_intersection_mask(base, lo_previous);
+                lo_previous_diff = diff(pixel_basher, base, lo_previous, base_vertical_edges, lo_previous_vertical_edges, lo_previous_intersection_mask, args.enable_minor_differences);
 
                 lo_compare = pixel_basher.compare_regressions(base, lo_diff, lo_previous_diff);
                 if (args.no_save_overlay)
@@ -238,7 +252,9 @@ int main(int argc, char *argv[])
             if (args.ms_previous)
             {
                 ms_conv_previous = args.ms_conv_previous_images[i];
-                ms_conv_previous_diff = diff(pixel_basher, base, ms_conv_previous, args.enable_minor_differences);
+                std::vector<bool> ms_conv_previous_vertical_edges = ms_conv_previous.get_filtered_vertical_edge_mask();
+                std::vector<bool> ms_conv_previous_intersection_mask = BMP::calculate_intersection_mask(base, ms_conv_previous);
+                ms_conv_previous_diff = diff(pixel_basher, base, ms_conv_previous, base_vertical_edges, ms_conv_previous_vertical_edges, ms_conv_previous_intersection_mask, args.enable_minor_differences);
 
                 ms_conv_compare = pixel_basher.compare_regressions(base, ms_conv_diff, ms_conv_previous_diff);
                 if (args.no_save_overlay)

--- a/src/pixelbasher.cpp
+++ b/src/pixelbasher.cpp
@@ -23,9 +23,10 @@ BMP pixelbasher::compare_bmps(const BMP &original, const BMP &target,
 
     BMP diff(original);
 
-    const std::vector<uint64_t> intersection_mask = BMP::calculate_intersection_mask_simd(original, target);
-    const std::vector<uint64_t> &original_vertical_edges = original.get_filtered_vertical_edge_mask();
-    const std::vector<uint64_t> &target_vertical_edges = target.get_filtered_vertical_edge_mask();
+    const std::vector<uint8_t> intersection_mask = BMP::calculate_intersection_mask_simd(original, target);
+
+    const std::vector<uint8_t> &original_vertical_edges = original.get_filtered_vertical_edge_mask();
+    const std::vector<uint8_t> &target_vertical_edges = target.get_filtered_vertical_edge_mask();
 
     int original_background_value = original.get_background_value();
 
@@ -36,13 +37,6 @@ BMP pixelbasher::compare_bmps(const BMP &original, const BMP &target,
 
     int original_width = original.get_width();
     int target_width = target.get_width();
-
-    auto get_bit = [&](const std::vector<uint64_t>& edge_map, int index) {
-        int byte_index = index / 64;
-        int bit_index = index % 64;
-        return (intersection_mask[byte_index] >> bit_index) & 1;
-    };
-
     // Loops through the min width and height, if size of images differ slightly.
     for (int y = 0; y < min_height; y++)
     {
@@ -59,13 +53,10 @@ BMP pixelbasher::compare_bmps(const BMP &original, const BMP &target,
             PixelValues original_pixel = Pixel::get_bgra(original_row);
             PixelValues target_pixel = Pixel::get_bgra(target_row);
 
-
-            bool near_edge = get_bit(intersection_mask, mask_index);
-            bool original_vertical_edge = get_bit(original_vertical_edges, mask_index);
-            bool target_vertical_edge = get_bit(target_vertical_edges, mask_index);
+            bool near_edge = intersection_mask[mask_index];
             bool vertical_edge = false;
 
-            if (original_vertical_edge || target_vertical_edge)
+            if (original_vertical_edges[mask_index] || target_vertical_edges[mask_index])
             {
                 vertical_edge = true;
             }

--- a/src/pixelbasher.cpp
+++ b/src/pixelbasher.cpp
@@ -15,7 +15,7 @@
 #include "pixel.hpp"
 #include "pixelbasher.hpp"
 
-BMP PixelBasher::compare_bmps(const BMP &original, const BMP &target,
+BMP pixelbasher::compare_bmps(const BMP &original, const BMP &target,
         bool enable_minor_differences)
 {
     int min_width = std::min(original.get_width(), target.get_width());
@@ -72,7 +72,7 @@ BMP PixelBasher::compare_bmps(const BMP &original, const BMP &target,
     return diff;
 }
 
-BMP PixelBasher::compare_regressions(const BMP &original, const BMP &current, BMP &previous)
+BMP pixelbasher::compare_regressions(const BMP &original, const BMP &current, BMP &previous)
 {
     std::int32_t min_width = std::min(original.get_width(), current.get_width());
     std::int32_t min_height = std::min(original.get_height(), current.get_height());
@@ -115,7 +115,7 @@ BMP PixelBasher::compare_regressions(const BMP &original, const BMP &current, BM
     return diff;
 }
 
-PixelValues PixelBasher::compare_pixels(PixelValues original, PixelValues target, BMP &diff, int original_background_value, bool near_edge, bool vertical_edge, bool minor_differences)
+PixelValues pixelbasher::compare_pixels(PixelValues original, PixelValues target, BMP &diff, int original_background_value, bool near_edge, bool vertical_edge, bool minor_differences)
 {
     const bool differs = Pixel::differs_from(original, target, near_edge, original_background_value);
 
@@ -143,7 +143,7 @@ PixelValues PixelBasher::compare_pixels(PixelValues original, PixelValues target
     return colour_to_pixel[Colour::RED];
 }
 
-PixelValues PixelBasher::compare_pixel_regression(BMP& diff, PixelValues original, PixelValues current, PixelValues previous)
+PixelValues pixelbasher::compare_pixel_regression(BMP& diff, PixelValues original, PixelValues current, PixelValues previous)
 {
     bool current_is_red = Pixel::is_red(current);
     bool previous_is_red = Pixel::is_red(previous);

--- a/src/pixelbasher.cpp
+++ b/src/pixelbasher.cpp
@@ -15,16 +15,16 @@
 #include "pixel.hpp"
 #include "pixelbasher.hpp"
 
-BMP PixelBasher::compare_bmps(const BMP &original, const BMP &target, bool enable_minor_differences)
+BMP PixelBasher::compare_bmps(const BMP &original, const BMP &target,
+        const std::vector<bool> &original_vertical_edges,
+        const std::vector<bool> &target_vertical_edges,
+        const std::vector<bool> &intersection_mask,
+        bool enable_minor_differences)
 {
     int min_width = std::min(original.get_width(), target.get_width());
     int min_height = std::min(original.get_height(), target.get_height());
 
     BMP diff(original);
-
-    std::vector<bool> intersection_mask = get_intersection_mask(original, target, min_width, min_height);
-    std::vector<bool> original_filtered_vertical_edges = original.get_filtered_vertical_edge_mask();
-    std::vector<bool> target_filtered_vertical_edges = target.get_filtered_vertical_edge_mask();
 
     int original_background_value = original.get_background_value();
 
@@ -54,7 +54,7 @@ BMP PixelBasher::compare_bmps(const BMP &original, const BMP &target, bool enabl
             bool near_edge = intersection_mask[mask_index];
             bool vertical_edge = false;
 
-            if (original_filtered_vertical_edges[mask_index] || target_filtered_vertical_edges[mask_index])
+            if (original_vertical_edges[mask_index] || target_vertical_edges[mask_index])
             {
                 vertical_edge = true;
             }
@@ -112,20 +112,6 @@ BMP PixelBasher::compare_regressions(const BMP &original, const BMP &current, BM
     }
     diff.set_data(diff_data);
     return diff;
-}
-
-std::vector<bool> PixelBasher::get_intersection_mask(const BMP &original, const BMP &target, int width, int height)
-{
-
-    std::vector<bool> original_edge_map = original.get_blurred_edge_mask();
-    std::vector<bool> target_edge_map = target.get_blurred_edge_mask();
-
-    std::vector<bool> intersection_mask(width * height, false);
-    for (int i = 0; i < width * height; i++)
-    {
-        intersection_mask[i] = original_edge_map[i] && target_edge_map[i];
-    }
-    return intersection_mask;
 }
 
 PixelValues PixelBasher::compare_pixels(PixelValues original, PixelValues target, BMP &diff, int original_background_value, bool near_edge, bool vertical_edge, bool minor_differences)

--- a/src/pixelbasher.cpp
+++ b/src/pixelbasher.cpp
@@ -23,9 +23,13 @@ BMP pixelbasher::compare_bmps(const BMP &original, const BMP &target,
 
     BMP diff(original);
 
-    const std::vector<bool> intersection_mask = BMP::calculate_intersection_mask(original, target);
-    const std::vector<bool> &original_vertical_edges = original.get_filtered_vertical_edge_mask();
-    const std::vector<bool> &target_vertical_edges = target.get_filtered_vertical_edge_mask();
+
+
+    // const std::vector<uint8_t> intersection_mask = BMP::calculate_intersection_mask(original, target);
+    const std::vector<uint8_t> intersection_mask = BMP::calculate_intersection_mask_simd(original, target);
+
+    const std::vector<uint8_t> &original_vertical_edges = original.get_filtered_vertical_edge_mask();
+    const std::vector<uint8_t> &target_vertical_edges = target.get_filtered_vertical_edge_mask();
 
     int original_background_value = original.get_background_value();
 

--- a/src/pixelbasher.cpp
+++ b/src/pixelbasher.cpp
@@ -23,10 +23,9 @@ BMP pixelbasher::compare_bmps(const BMP &original, const BMP &target,
 
     BMP diff(original);
 
-    const std::vector<uint8_t> intersection_mask = BMP::calculate_intersection_mask_simd(original, target);
-
-    const std::vector<uint8_t> &original_vertical_edges = original.get_filtered_vertical_edge_mask();
-    const std::vector<uint8_t> &target_vertical_edges = target.get_filtered_vertical_edge_mask();
+    const std::vector<uint64_t> intersection_mask = BMP::calculate_intersection_mask_simd(original, target);
+    const std::vector<uint64_t> &original_vertical_edges = original.get_filtered_vertical_edge_mask();
+    const std::vector<uint64_t> &target_vertical_edges = target.get_filtered_vertical_edge_mask();
 
     int original_background_value = original.get_background_value();
 
@@ -37,6 +36,13 @@ BMP pixelbasher::compare_bmps(const BMP &original, const BMP &target,
 
     int original_width = original.get_width();
     int target_width = target.get_width();
+
+    auto get_bit = [&](const std::vector<uint64_t>& edge_map, int index) {
+        int byte_index = index / 64;
+        int bit_index = index % 64;
+        return (intersection_mask[byte_index] >> bit_index) & 1;
+    };
+
     // Loops through the min width and height, if size of images differ slightly.
     for (int y = 0; y < min_height; y++)
     {
@@ -53,10 +59,13 @@ BMP pixelbasher::compare_bmps(const BMP &original, const BMP &target,
             PixelValues original_pixel = Pixel::get_bgra(original_row);
             PixelValues target_pixel = Pixel::get_bgra(target_row);
 
-            bool near_edge = intersection_mask[mask_index];
+
+            bool near_edge = get_bit(intersection_mask, mask_index);
+            bool original_vertical_edge = get_bit(original_vertical_edges, mask_index);
+            bool target_vertical_edge = get_bit(target_vertical_edges, mask_index);
             bool vertical_edge = false;
 
-            if (original_vertical_edges[mask_index] || target_vertical_edges[mask_index])
+            if (original_vertical_edge || target_vertical_edge)
             {
                 vertical_edge = true;
             }

--- a/src/pixelbasher.cpp
+++ b/src/pixelbasher.cpp
@@ -16,15 +16,16 @@
 #include "pixelbasher.hpp"
 
 BMP PixelBasher::compare_bmps(const BMP &original, const BMP &target,
-        const std::vector<bool> &original_vertical_edges,
-        const std::vector<bool> &target_vertical_edges,
-        const std::vector<bool> &intersection_mask,
         bool enable_minor_differences)
 {
     int min_width = std::min(original.get_width(), target.get_width());
     int min_height = std::min(original.get_height(), target.get_height());
 
     BMP diff(original);
+
+    const std::vector<bool> intersection_mask = BMP::calculate_intersection_mask(original, target);
+    const std::vector<bool> &original_vertical_edges = original.get_filtered_vertical_edge_mask();
+    const std::vector<bool> &target_vertical_edges = target.get_filtered_vertical_edge_mask();
 
     int original_background_value = original.get_background_value();
 

--- a/src/pixelbasher.cpp
+++ b/src/pixelbasher.cpp
@@ -23,9 +23,6 @@ BMP pixelbasher::compare_bmps(const BMP &original, const BMP &target,
 
     BMP diff(original);
 
-
-
-    // const std::vector<uint8_t> intersection_mask = BMP::calculate_intersection_mask(original, target);
     const std::vector<uint8_t> intersection_mask = BMP::calculate_intersection_mask_simd(original, target);
 
     const std::vector<uint8_t> &original_vertical_edges = original.get_filtered_vertical_edge_mask();

--- a/src/pixelbasher.hpp
+++ b/src/pixelbasher.hpp
@@ -28,5 +28,5 @@ namespace pixelbasher
     PixelValues compare_pixel_regression(BMP& diff, PixelValues original, PixelValues current, PixelValues previous);
     PixelValues compare_pixels(PixelValues original, PixelValues target, BMP &diff, int original_background_value, bool near_edge, bool vertical_edge, bool minor_differences);
     PixelValues colour_pixel(Colour colour);
-};
+}
 #endif

--- a/src/pixelbasher.hpp
+++ b/src/pixelbasher.hpp
@@ -23,11 +23,13 @@ class PixelBasher
 {
 public:
     // Compares two BMP images and generates a diff image based on the differences (the diff is applied to the base image)
-    static BMP compare_bmps(const BMP &original, const BMP &target, bool enable_minor_differences);
+    static BMP compare_bmps(const BMP &original, const BMP &target,
+        const std::vector<bool> &original_vertical_edges,
+        const std::vector<bool> &target_vertical_edges,
+        const std::vector<bool> &intersection_mask,
+        bool enable_minor_differences);
     static BMP compare_regressions(const BMP &original, const BMP &current, BMP &previous);
-
 private:
-    static std::vector<bool> get_intersection_mask(const BMP &original, const BMP &target, int min_width, int min_height);
     static PixelValues compare_pixel_regression(BMP& diff, PixelValues original, PixelValues current, PixelValues previous);
     static PixelValues compare_pixels(PixelValues original, PixelValues target, BMP &diff, int original_background_value, bool near_edge, bool vertical_edge, bool minor_differences);
     static PixelValues colour_pixel(Colour colour);

--- a/src/pixelbasher.hpp
+++ b/src/pixelbasher.hpp
@@ -23,11 +23,7 @@ class PixelBasher
 {
 public:
     // Compares two BMP images and generates a diff image based on the differences (the diff is applied to the base image)
-    static BMP compare_bmps(const BMP &original, const BMP &target,
-        const std::vector<bool> &original_vertical_edges,
-        const std::vector<bool> &target_vertical_edges,
-        const std::vector<bool> &intersection_mask,
-        bool enable_minor_differences);
+    static BMP compare_bmps(const BMP &original, const BMP &target, bool enable_minor_differences);
     static BMP compare_regressions(const BMP &original, const BMP &current, BMP &previous);
 private:
     static PixelValues compare_pixel_regression(BMP& diff, PixelValues original, PixelValues current, PixelValues previous);

--- a/src/pixelbasher.hpp
+++ b/src/pixelbasher.hpp
@@ -19,15 +19,14 @@
 #include "pixel.hpp"
 
 // PixelBasher class to handle the comparison of BMP images and generate diff images
-class PixelBasher
+namespace pixelbasher
 {
-public:
     // Compares two BMP images and generates a diff image based on the differences (the diff is applied to the base image)
-    static BMP compare_bmps(const BMP &original, const BMP &target, bool enable_minor_differences);
-    static BMP compare_regressions(const BMP &original, const BMP &current, BMP &previous);
-private:
-    static PixelValues compare_pixel_regression(BMP& diff, PixelValues original, PixelValues current, PixelValues previous);
-    static PixelValues compare_pixels(PixelValues original, PixelValues target, BMP &diff, int original_background_value, bool near_edge, bool vertical_edge, bool minor_differences);
-    static PixelValues colour_pixel(Colour colour);
+    BMP compare_bmps(const BMP &original, const BMP &target, bool enable_minor_differences);
+    BMP compare_regressions(const BMP &original, const BMP &current, BMP &previous);
+
+    PixelValues compare_pixel_regression(BMP& diff, PixelValues original, PixelValues current, PixelValues previous);
+    PixelValues compare_pixels(PixelValues original, PixelValues target, BMP &diff, int original_background_value, bool near_edge, bool vertical_edge, bool minor_differences);
+    PixelValues colour_pixel(Colour colour);
 };
 #endif

--- a/test/makefile
+++ b/test/makefile
@@ -3,7 +3,7 @@ OBJ_DIR = obj
 TARGET = unittest
 
 CXX = g++
-CXXFLAGS = -std=c++20 -Wall -g -MMD -MP -I../src
+CXXFLAGS = -std=c++20 -Wall -g -MMD -MP -I../src -mavx2
 Catch2_CFLAGS = $(shell pkg-config --cflags catch2)
 Catch2_LDFLAGS = $(shell pkg-config --libs catch2-with-main)
 

--- a/test/test_bmp.cpp
+++ b/test/test_bmp.cpp
@@ -3,14 +3,6 @@
 
 using Catch::Matchers::ContainsSubstring;
 
-int count_set_bits(const std::vector<uint64_t>& mask) {
-    int total = 0;
-    for (uint64_t x : mask) {
-        total += std::popcount(x);
-    }
-    return total;
-}
-
 TEST_CASE("BMP Class Constructor", "[bmp][constructor]") {
     SECTION("Default constructor creates an empty BMP object") {
         BMP bmp;
@@ -19,21 +11,21 @@ TEST_CASE("BMP Class Constructor", "[bmp][constructor]") {
         REQUIRE(bmp.get_data().empty());
         REQUIRE(bmp.get_red_count() == 0);
         REQUIRE(bmp.get_yellow_count() == 0);
-        REQUIRE(count_set_bits(bmp.get_blurred_edge_mask()) == 0);
-        REQUIRE(count_set_bits(bmp.get_vertical_edge_mask()) == 0);
+        REQUIRE(std::count(bmp.get_blurred_edge_mask().begin(), bmp.get_blurred_edge_mask().end(), 1) == 0);
+        REQUIRE(std::count(bmp.get_filtered_vertical_edge_mask().begin(), bmp.get_filtered_vertical_edge_mask().end(), 1) == 0);
     }
 
     SECTION("Constructor with width and height initializes BMP with correct dimensions") {
         BMP bmp(100, 100);
-        std::vector<uint64_t> bmp_blurred_edge_mask = bmp.get_blurred_edge_mask();
-        std::vector<uint64_t> bmp_filtered_vertical_edge_mask = bmp.get_filtered_vertical_edge_mask();
+        std::vector<uint8_t> bmp_blurred_edge_mask = bmp.get_blurred_edge_mask();
+        std::vector<uint8_t> bmp_filtered_vertical_edge_mask = bmp.get_filtered_vertical_edge_mask();
         REQUIRE(bmp.get_width() == 100);
         REQUIRE(bmp.get_height() == 100);
         REQUIRE(bmp.get_data().size() == 100 * 100 * pixel_stride);
         REQUIRE(bmp.get_red_count() == 0);
         REQUIRE(bmp.get_yellow_count() == 0);
-        REQUIRE(count_set_bits(bmp_blurred_edge_mask) == 0);
-        REQUIRE(count_set_bits(bmp_filtered_vertical_edge_mask) == 0);
+        REQUIRE(std::count(bmp_blurred_edge_mask.begin(), bmp_blurred_edge_mask.end(), 1) == 0);
+        REQUIRE(std::count(bmp_filtered_vertical_edge_mask.begin(), bmp_filtered_vertical_edge_mask.end(), 1) == 0);
     }
 }
 
@@ -91,10 +83,7 @@ TEST_CASE("Writing BMP files", "[bmp][write]") {
 TEST_CASE("Writing filters & masks onto BMP files", "[bmp][write]") {
     SECTION("Creates and writes a BMP with an edge_mask successfully") {
         BMP dummy_image(100, 100);
-
-        int n_pixels = dummy_image.get_width() * dummy_image.get_height();
-        int mask_size = (n_pixels + 63) / 64;
-        std::vector<uint64_t> edge_mask (mask_size, 1);
+        std::vector<uint8_t> edge_mask (100 * 100, 1);
 
         REQUIRE_NOTHROW(BMP::write_with_filter(dummy_image, "test_data/output/write-filter.bmp", edge_mask));
     }
@@ -104,17 +93,14 @@ TEST_CASE("Writing filters & masks onto BMP files", "[bmp][write]") {
         BMP dummy_image(100, 100);
         int dummy_image_red_count = BMP::calculate_colour_count(dummy_image, Colour::RED);
 
-        int n_pixels = dummy_image.get_width() * dummy_image.get_height();
-        int mask_size = (n_pixels + 63) / 64;
-        std::vector<uint64_t> edge_mask (mask_size, 1);
-
+        std::vector<uint8_t> edge_mask (100 * 100, 1);
         BMP::write_with_filter(dummy_image, bmp_path, edge_mask);
 
         BMP dummy_image_input(bmp_path);
         int dummy_image_input_red_count = BMP::calculate_colour_count(dummy_image_input, Colour::RED);
 
         REQUIRE(dummy_image_red_count == 0);
-        REQUIRE(dummy_image_input_red_count == count_set_bits(edge_mask));
+        REQUIRE(dummy_image_input_red_count == (int)edge_mask.size());
     }
 }
 
@@ -213,23 +199,23 @@ TEST_CASE("Setting the pixel data", "[bmp][set_data]") {
 TEST_CASE("Running sobel edge detection", "[bmp][pixel-analysis]") {
     SECTION("Returns no edges for solid_black.bmp") {
         BMP solid_black ("test_data/solid_black.bmp");
-        std::vector<uint64_t> sobel_edge_mask = solid_black.get_sobel_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = solid_black.get_sobel_edge_mask();
 
-        REQUIRE(count_set_bits(sobel_edge_mask) == 0);
+        REQUIRE(std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1) == 0);
     }
 
     SECTION("Returns that edges exist for edges.bmp") {
         BMP edges ("test_data/edges.bmp");
-        std::vector<uint64_t> sobel_edge_mask = edges.get_sobel_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = edges.get_sobel_edge_mask();
 
-        REQUIRE(count_set_bits(sobel_edge_mask) > 0);
+        REQUIRE(std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1) > 0);
     }
 
     SECTION("Returns that edges exist for vertical_edges.bmp") {
         BMP vertical_edges ("test_data/vertical_edges.bmp");
-        std::vector<uint64_t> sobel_edge_mask = vertical_edges.get_sobel_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = vertical_edges.get_sobel_edge_mask();
 
-        REQUIRE(count_set_bits(sobel_edge_mask) > 0);
+        REQUIRE(std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1) > 0);
     }
 }
 
@@ -237,11 +223,11 @@ TEST_CASE("Blurring the sobel edge mask", "[bmp][pixel-analysis]") {
     SECTION("Sobel edge count remains the same as blurred edge mask") {
         BMP solid_black ("test_data/solid_black.bmp");
 
-        std::vector<uint64_t> sobel_edge_mask = solid_black.get_sobel_edge_mask();
-        std::vector<uint64_t> blurred_edge_mask = solid_black.get_blurred_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = solid_black.get_sobel_edge_mask();
+        std::vector<uint8_t> blurred_edge_mask = solid_black.get_blurred_edge_mask();
 
-        int sobel_edge_count = count_set_bits(sobel_edge_mask);
-        int blurred_edge_count = count_set_bits(blurred_edge_mask);
+        int sobel_edge_count = std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1);
+        int blurred_edge_count = std::count(blurred_edge_mask.begin(), blurred_edge_mask.end(), 1);
 
         REQUIRE(blurred_edge_count == 0); // no edges in solid black image
         REQUIRE(sobel_edge_count == blurred_edge_count);
@@ -250,11 +236,11 @@ TEST_CASE("Blurring the sobel edge mask", "[bmp][pixel-analysis]") {
     SECTION("Returns a larger edge count for blurred edge mask than sobel edge mask") {
         BMP edges ("test_data/edges.bmp");
 
-        std::vector<uint64_t> sobel_edge_mask = edges.get_sobel_edge_mask();
-        std::vector<uint64_t> blurred_edge_mask = edges.get_blurred_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = edges.get_sobel_edge_mask();
+        std::vector<uint8_t> blurred_edge_mask = edges.get_blurred_edge_mask();
 
-        int sobel_edge_count = count_set_bits(sobel_edge_mask);
-        int blurred_edge_count = count_set_bits(blurred_edge_mask);
+        int sobel_edge_count = std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1);
+        int blurred_edge_count = std::count(blurred_edge_mask.begin(), blurred_edge_mask.end(), 1);
 
         REQUIRE(blurred_edge_count != 0);
         REQUIRE(blurred_edge_count > sobel_edge_count);
@@ -264,35 +250,35 @@ TEST_CASE("Blurring the sobel edge mask", "[bmp][pixel-analysis]") {
 TEST_CASE("Running vertical edge detection", "[bmp][pixel-analysis]") {
     SECTION("Returns no vertical edges for solid_black.bmp") {
         BMP solid_black ("test_data/solid_black.bmp");
-        std::vector<uint64_t> vertical_edge_mask = solid_black.get_vertical_edge_mask();
+        std::vector<uint8_t> vertical_edge_mask = solid_black.get_vertical_edge_mask();
 
-        REQUIRE(count_set_bits(vertical_edge_mask) == 0);
+        REQUIRE(std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), 1) == 0);
     }
 
     SECTION("Returns that vertical edges exist for vertical_edges.bmp") {
         BMP vertical_edges ("test_data/vertical_edges.bmp");
-        std::vector<uint64_t> vertical_edge_mask = vertical_edges.get_vertical_edge_mask();
+        std::vector<uint8_t> vertical_edge_mask = vertical_edges.get_vertical_edge_mask();
 
-        REQUIRE(count_set_bits(vertical_edge_mask) > 0);
+        REQUIRE(std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), 1) > 0);
     }
 }
 
 TEST_CASE("Running filtered vertical edge detection", "[bmp][pixel-analysis]") {
     SECTION("filtered vertical edges returns the same as vertical edges") {
         BMP solid_black ("test_data/solid_black.bmp");
-        std::vector<uint64_t> vertical_edge_mask = solid_black.get_vertical_edge_mask();
+        std::vector<uint8_t> vertical_edge_mask = solid_black.get_vertical_edge_mask();
 
-        REQUIRE(count_set_bits(vertical_edge_mask) == 0);
+        REQUIRE(std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), 1) == 0);
     }
 
     SECTION("Returns a smaller amount of vertical edges compared to total edges") {
         BMP edges ("test_data/edges.bmp");
 
-        std::vector<uint64_t> vertical_edge_mask = edges.get_vertical_edge_mask();
-        std::vector<uint64_t> blurred_edge_mask = edges.get_blurred_edge_mask();
+        std::vector<uint8_t> vertical_edge_mask = edges.get_vertical_edge_mask();
+        std::vector<uint8_t> blurred_edge_mask = edges.get_blurred_edge_mask();
 
-        int vertical_edge_count = count_set_bits(vertical_edge_mask);
-        int blurred_edge_count = count_set_bits(blurred_edge_mask);
+        int vertical_edge_count = std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), 1);
+        int blurred_edge_count = std::count(blurred_edge_mask.begin(), blurred_edge_mask.end(), 1);
 
         REQUIRE(blurred_edge_count > vertical_edge_count);
     }
@@ -301,8 +287,8 @@ TEST_CASE("Running filtered vertical edge detection", "[bmp][pixel-analysis]") {
     SECTION("Returns a positive filtered edge count") {
         BMP vertical_edges ("test_data/vertical_edges.bmp");
 
-        std::vector<uint64_t> filtered_edge_mask = vertical_edges.get_blurred_edge_mask();
-        int filtered_edge_count = count_set_bits(filtered_edge_mask);
+        std::vector<uint8_t> filtered_edge_mask = vertical_edges.get_blurred_edge_mask();
+        int filtered_edge_count = std::count(filtered_edge_mask.begin(), filtered_edge_mask.end(), 1);
 
         REQUIRE(filtered_edge_count > 0);
     }

--- a/test/test_bmp.cpp
+++ b/test/test_bmp.cpp
@@ -11,21 +11,21 @@ TEST_CASE("BMP Class Constructor", "[bmp][constructor]") {
         REQUIRE(bmp.get_data().empty());
         REQUIRE(bmp.get_red_count() == 0);
         REQUIRE(bmp.get_yellow_count() == 0);
-        REQUIRE(std::count(bmp.get_blurred_edge_mask().begin(), bmp.get_blurred_edge_mask().end(), true) == 0);
-        REQUIRE(std::count(bmp.get_filtered_vertical_edge_mask().begin(), bmp.get_filtered_vertical_edge_mask().end(), true) == 0);
+        REQUIRE(std::count(bmp.get_blurred_edge_mask().begin(), bmp.get_blurred_edge_mask().end(), 1) == 0);
+        REQUIRE(std::count(bmp.get_filtered_vertical_edge_mask().begin(), bmp.get_filtered_vertical_edge_mask().end(), 1) == 0);
     }
 
     SECTION("Constructor with width and height initializes BMP with correct dimensions") {
         BMP bmp(100, 100);
-        std::vector<bool> bmp_blurred_edge_mask = bmp.get_blurred_edge_mask();
-        std::vector<bool> bmp_filtered_vertical_edge_mask = bmp.get_filtered_vertical_edge_mask();
+        std::vector<uint8_t> bmp_blurred_edge_mask = bmp.get_blurred_edge_mask();
+        std::vector<uint8_t> bmp_filtered_vertical_edge_mask = bmp.get_filtered_vertical_edge_mask();
         REQUIRE(bmp.get_width() == 100);
         REQUIRE(bmp.get_height() == 100);
         REQUIRE(bmp.get_data().size() == 100 * 100 * pixel_stride);
         REQUIRE(bmp.get_red_count() == 0);
         REQUIRE(bmp.get_yellow_count() == 0);
-        REQUIRE(std::count(bmp_blurred_edge_mask.begin(), bmp_blurred_edge_mask.end(), true) == 0);
-        REQUIRE(std::count(bmp_filtered_vertical_edge_mask.begin(), bmp_filtered_vertical_edge_mask.end(), true) == 0);
+        REQUIRE(std::count(bmp_blurred_edge_mask.begin(), bmp_blurred_edge_mask.end(), 1) == 0);
+        REQUIRE(std::count(bmp_filtered_vertical_edge_mask.begin(), bmp_filtered_vertical_edge_mask.end(), 1) == 0);
     }
 }
 
@@ -83,7 +83,7 @@ TEST_CASE("Writing BMP files", "[bmp][write]") {
 TEST_CASE("Writing filters & masks onto BMP files", "[bmp][write]") {
     SECTION("Creates and writes a BMP with an edge_mask successfully") {
         BMP dummy_image(100, 100);
-        std::vector<bool> edge_mask (100 * 100, true);
+        std::vector<uint8_t> edge_mask (100 * 100, 1);
 
         REQUIRE_NOTHROW(BMP::write_with_filter(dummy_image, "test_data/output/write-filter.bmp", edge_mask));
     }
@@ -93,7 +93,7 @@ TEST_CASE("Writing filters & masks onto BMP files", "[bmp][write]") {
         BMP dummy_image(100, 100);
         int dummy_image_red_count = BMP::calculate_colour_count(dummy_image, Colour::RED);
 
-        std::vector<bool> edge_mask (100 * 100, true);
+        std::vector<uint8_t> edge_mask (100 * 100, 1);
         BMP::write_with_filter(dummy_image, bmp_path, edge_mask);
 
         BMP dummy_image_input(bmp_path);
@@ -199,23 +199,23 @@ TEST_CASE("Setting the pixel data", "[bmp][set_data]") {
 TEST_CASE("Running sobel edge detection", "[bmp][pixel-analysis]") {
     SECTION("Returns no edges for solid_black.bmp") {
         BMP solid_black ("test_data/solid_black.bmp");
-        std::vector<bool> sobel_edge_mask = solid_black.get_sobel_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = solid_black.get_sobel_edge_mask();
 
-        REQUIRE(std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), true) == 0);
+        REQUIRE(std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1) == 0);
     }
 
     SECTION("Returns that edges exist for edges.bmp") {
         BMP edges ("test_data/edges.bmp");
-        std::vector<bool> sobel_edge_mask = edges.get_sobel_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = edges.get_sobel_edge_mask();
 
-        REQUIRE(std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), true) > 0);
+        REQUIRE(std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1) > 0);
     }
 
     SECTION("Returns that edges exist for vertical_edges.bmp") {
         BMP vertical_edges ("test_data/vertical_edges.bmp");
-        std::vector<bool> sobel_edge_mask = vertical_edges.get_sobel_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = vertical_edges.get_sobel_edge_mask();
 
-        REQUIRE(std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), true) > 0);
+        REQUIRE(std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1) > 0);
     }
 }
 
@@ -223,11 +223,11 @@ TEST_CASE("Blurring the sobel edge mask", "[bmp][pixel-analysis]") {
     SECTION("Sobel edge count remains the same as blurred edge mask") {
         BMP solid_black ("test_data/solid_black.bmp");
 
-        std::vector<bool> sobel_edge_mask = solid_black.get_sobel_edge_mask();
-        std::vector<bool> blurred_edge_mask = solid_black.get_blurred_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = solid_black.get_sobel_edge_mask();
+        std::vector<uint8_t> blurred_edge_mask = solid_black.get_blurred_edge_mask();
 
-        int sobel_edge_count = std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), true);
-        int blurred_edge_count = std::count(blurred_edge_mask.begin(), blurred_edge_mask.end(), true);
+        int sobel_edge_count = std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1);
+        int blurred_edge_count = std::count(blurred_edge_mask.begin(), blurred_edge_mask.end(), 1);
 
         REQUIRE(blurred_edge_count == 0); // no edges in solid black image
         REQUIRE(sobel_edge_count == blurred_edge_count);
@@ -236,11 +236,11 @@ TEST_CASE("Blurring the sobel edge mask", "[bmp][pixel-analysis]") {
     SECTION("Returns a larger edge count for blurred edge mask than sobel edge mask") {
         BMP edges ("test_data/edges.bmp");
 
-        std::vector<bool> sobel_edge_mask = edges.get_sobel_edge_mask();
-        std::vector<bool> blurred_edge_mask = edges.get_blurred_edge_mask();
+        std::vector<uint8_t> sobel_edge_mask = edges.get_sobel_edge_mask();
+        std::vector<uint8_t> blurred_edge_mask = edges.get_blurred_edge_mask();
 
-        int sobel_edge_count = std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), true);
-        int blurred_edge_count = std::count(blurred_edge_mask.begin(), blurred_edge_mask.end(), true);
+        int sobel_edge_count = std::count(sobel_edge_mask.begin(), sobel_edge_mask.end(), 1);
+        int blurred_edge_count = std::count(blurred_edge_mask.begin(), blurred_edge_mask.end(), 1);
 
         REQUIRE(blurred_edge_count != 0);
         REQUIRE(blurred_edge_count > sobel_edge_count);
@@ -250,35 +250,35 @@ TEST_CASE("Blurring the sobel edge mask", "[bmp][pixel-analysis]") {
 TEST_CASE("Running vertical edge detection", "[bmp][pixel-analysis]") {
     SECTION("Returns no vertical edges for solid_black.bmp") {
         BMP solid_black ("test_data/solid_black.bmp");
-        std::vector<bool> vertical_edge_mask = solid_black.get_vertical_edge_mask();
+        std::vector<uint8_t> vertical_edge_mask = solid_black.get_vertical_edge_mask();
 
-        REQUIRE(std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), true) == 0);
+        REQUIRE(std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), 1) == 0);
     }
 
     SECTION("Returns that vertical edges exist for vertical_edges.bmp") {
         BMP vertical_edges ("test_data/vertical_edges.bmp");
-        std::vector<bool> vertical_edge_mask = vertical_edges.get_vertical_edge_mask();
+        std::vector<uint8_t> vertical_edge_mask = vertical_edges.get_vertical_edge_mask();
 
-        REQUIRE(std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), true) > 0);
+        REQUIRE(std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), 1) > 0);
     }
 }
 
 TEST_CASE("Running filtered vertical edge detection", "[bmp][pixel-analysis]") {
     SECTION("filtered vertical edges returns the same as vertical edges") {
         BMP solid_black ("test_data/solid_black.bmp");
-        std::vector<bool> vertical_edge_mask = solid_black.get_vertical_edge_mask();
+        std::vector<uint8_t> vertical_edge_mask = solid_black.get_vertical_edge_mask();
 
-        REQUIRE(std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), true) == 0);
+        REQUIRE(std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), 1) == 0);
     }
 
     SECTION("Returns a smaller amount of vertical edges compared to total edges") {
         BMP edges ("test_data/edges.bmp");
 
-        std::vector<bool> vertical_edge_mask = edges.get_vertical_edge_mask();
-        std::vector<bool> blurred_edge_mask = edges.get_blurred_edge_mask();
+        std::vector<uint8_t> vertical_edge_mask = edges.get_vertical_edge_mask();
+        std::vector<uint8_t> blurred_edge_mask = edges.get_blurred_edge_mask();
 
-        int vertical_edge_count = std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), true);
-        int blurred_edge_count = std::count(blurred_edge_mask.begin(), blurred_edge_mask.end(), true);
+        int vertical_edge_count = std::count(vertical_edge_mask.begin(), vertical_edge_mask.end(), 1);
+        int blurred_edge_count = std::count(blurred_edge_mask.begin(), blurred_edge_mask.end(), 1);
 
         REQUIRE(blurred_edge_count > vertical_edge_count);
     }
@@ -287,8 +287,8 @@ TEST_CASE("Running filtered vertical edge detection", "[bmp][pixel-analysis]") {
     SECTION("Returns a positive filtered edge count") {
         BMP vertical_edges ("test_data/vertical_edges.bmp");
 
-        std::vector<bool> filtered_edge_mask = vertical_edges.get_blurred_edge_mask();
-        int filtered_edge_count = std::count(filtered_edge_mask.begin(), filtered_edge_mask.end(), true);
+        std::vector<uint8_t> filtered_edge_mask = vertical_edges.get_blurred_edge_mask();
+        int filtered_edge_count = std::count(filtered_edge_mask.begin(), filtered_edge_mask.end(), 1);
 
         REQUIRE(filtered_edge_count > 0);
     }

--- a/test/test_bmp.cpp
+++ b/test/test_bmp.cpp
@@ -17,13 +17,15 @@ TEST_CASE("BMP Class Constructor", "[bmp][constructor]") {
 
     SECTION("Constructor with width and height initializes BMP with correct dimensions") {
         BMP bmp(100, 100);
+        std::vector<bool> bmp_blurred_edge_mask = bmp.get_blurred_edge_mask();
+        std::vector<bool> bmp_filtered_vertical_edge_mask = bmp.get_filtered_vertical_edge_mask();
         REQUIRE(bmp.get_width() == 100);
         REQUIRE(bmp.get_height() == 100);
         REQUIRE(bmp.get_data().size() == 100 * 100 * pixel_stride);
         REQUIRE(bmp.get_red_count() == 0);
         REQUIRE(bmp.get_yellow_count() == 0);
-        REQUIRE(std::count(bmp.get_blurred_edge_mask().begin(), bmp.get_blurred_edge_mask().end(), true) == 0);
-        REQUIRE(std::count(bmp.get_filtered_vertical_edge_mask().begin(), bmp.get_filtered_vertical_edge_mask().end(), true) == 0);
+        REQUIRE(std::count(bmp_blurred_edge_mask.begin(), bmp_blurred_edge_mask.end(), true) == 0);
+        REQUIRE(std::count(bmp_filtered_vertical_edge_mask.begin(), bmp_filtered_vertical_edge_mask.end(), true) == 0);
     }
 }
 

--- a/test/test_pixelbasher.cpp
+++ b/test/test_pixelbasher.cpp
@@ -3,12 +3,12 @@
 
 using Catch::Matchers::ContainsSubstring;
 
-TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
+TEST_CASE("pixelbasher compare two BMP's", "[pixelbasher][compare]") {
     SECTION("Compare two different BMPs and generate a diff image with minor differences disabled") {
         BMP original("test_data/solid_white.bmp");
         BMP target("test_data/vertical_edges.bmp");
 
-        BMP diff = PixelBasher::compare_bmps(original, target, false);
+        BMP diff = pixelbasher::compare_bmps(original, target, false);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -19,7 +19,7 @@ TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
         BMP original("test_data/solid_white.bmp");
         BMP target("test_data/solid_white.bmp");
 
-        BMP diff = PixelBasher::compare_bmps(original, target, false);
+        BMP diff = pixelbasher::compare_bmps(original, target, false);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -30,7 +30,7 @@ TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
         BMP original("test_data/text.bmp");
         BMP target("test_data/slightly-different-text.bmp");
 
-        BMP diff = PixelBasher::compare_bmps(original, target, true);
+        BMP diff = pixelbasher::compare_bmps(original, target, true);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -38,15 +38,15 @@ TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
     }
 }
 
-TEST_CASE("PixelBasher compare regression", "[pixelbasher][regression]") {
+TEST_CASE("pixelbasher compare regression", "[pixelbasher][regression]") {
     SECTION("Compare differences with regressed BMP version versus previous regressed BMP version") {
         BMP original("test_data/solid_white.bmp");
         BMP current("test_data/solid_black.bmp");
         BMP previous("test_data/vertical_edges.bmp");
 
-        BMP current_diff = PixelBasher::compare_bmps(original, current, false);
-        BMP previous_diff = PixelBasher::compare_bmps(original, previous, false);
-        BMP diff = PixelBasher::compare_regressions(original, current_diff, previous_diff);
+        BMP current_diff = pixelbasher::compare_bmps(original, current, false);
+        BMP previous_diff = pixelbasher::compare_bmps(original, previous, false);
+        BMP diff = pixelbasher::compare_regressions(original, current_diff, previous_diff);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -59,9 +59,9 @@ TEST_CASE("PixelBasher compare regression", "[pixelbasher][regression]") {
         BMP current("test_data/solid_white.bmp");
         BMP previous("test_data/solid_black.bmp");
 
-        BMP current_diff = PixelBasher::compare_bmps(original, current, false);
-        BMP previous_diff = PixelBasher::compare_bmps(original, previous, false);
-        BMP diff = PixelBasher::compare_regressions(original, current_diff, previous_diff);
+        BMP current_diff = pixelbasher::compare_bmps(original, current, false);
+        BMP previous_diff = pixelbasher::compare_bmps(original, previous, false);
+        BMP diff = pixelbasher::compare_regressions(original, current_diff, previous_diff);
 
         int diff_size = diff.get_width() * diff.get_height();
 

--- a/test/test_pixelbasher.cpp
+++ b/test/test_pixelbasher.cpp
@@ -8,11 +8,7 @@ TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
         BMP original("test_data/solid_white.bmp");
         BMP target("test_data/vertical_edges.bmp");
 
-        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
-        std::vector<bool> target_vertical_edges = target.get_filtered_vertical_edge_mask();
-        std::vector<bool> intersection_mask = BMP::calculate_intersection_mask(original, target);
-
-        BMP diff = PixelBasher::compare_bmps(original, target, base_vertical_edges, target_vertical_edges, intersection_mask, false);
+        BMP diff = PixelBasher::compare_bmps(original, target, false);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -23,11 +19,7 @@ TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
         BMP original("test_data/solid_white.bmp");
         BMP target("test_data/solid_white.bmp");
 
-        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
-        std::vector<bool> target_vertical_edges = target.get_filtered_vertical_edge_mask();
-        std::vector<bool> intersection_mask = BMP::calculate_intersection_mask(original, target);
-
-        BMP diff = PixelBasher::compare_bmps(original, target, base_vertical_edges, target_vertical_edges, intersection_mask, false);
+        BMP diff = PixelBasher::compare_bmps(original, target, false);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -38,11 +30,7 @@ TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
         BMP original("test_data/text.bmp");
         BMP target("test_data/slightly-different-text.bmp");
 
-        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
-        std::vector<bool> target_vertical_edges = target.get_filtered_vertical_edge_mask();
-        std::vector<bool> intersection_mask = BMP::calculate_intersection_mask(original, target);
-
-        BMP diff = PixelBasher::compare_bmps(original, target, base_vertical_edges, target_vertical_edges, intersection_mask, true);
+        BMP diff = PixelBasher::compare_bmps(original, target, true);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -56,16 +44,11 @@ TEST_CASE("PixelBasher compare regression", "[pixelbasher][regression]") {
         BMP current("test_data/solid_black.bmp");
         BMP previous("test_data/vertical_edges.bmp");
 
-        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
-        std::vector<bool> current_vertical_edges = current.get_filtered_vertical_edge_mask();
-        std::vector<bool> previous_current_edges = previous.get_filtered_vertical_edge_mask();
-
-        std::vector<bool> current_intersection_mask = BMP::calculate_intersection_mask(original, current);
-        std::vector<bool> previous_intersection_mask = BMP::calculate_intersection_mask(original, previous);
-
-        BMP current_diff = PixelBasher::compare_bmps(original, current, base_vertical_edges, current_vertical_edges, current_intersection_mask, false);
-        BMP previous_diff = PixelBasher::compare_bmps(original, current, base_vertical_edges, previous_current_edges, previous_intersection_mask, false);
+        BMP current_diff = PixelBasher::compare_bmps(original, current,  false);
+        BMP previous_diff = PixelBasher::compare_bmps(original, previous, false);
         BMP diff = PixelBasher::compare_regressions(original, current_diff, previous_diff);
+
+        diff.write("test_data/output/new-diff.bmp");
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -78,15 +61,8 @@ TEST_CASE("PixelBasher compare regression", "[pixelbasher][regression]") {
         BMP current("test_data/solid_white.bmp");
         BMP previous("test_data/solid_black.bmp");
 
-        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
-        std::vector<bool> current_vertical_edges = current.get_filtered_vertical_edge_mask();
-        std::vector<bool> previous_current_edges = previous.get_filtered_vertical_edge_mask();
-
-        std::vector<bool> current_intersection_mask = BMP::calculate_intersection_mask(original, current);
-        std::vector<bool> previous_intersection_mask = BMP::calculate_intersection_mask(original, previous);
-
-        BMP current_diff = PixelBasher::compare_bmps(original, current, base_vertical_edges, current_vertical_edges, current_intersection_mask, false);
-        BMP previous_diff = PixelBasher::compare_bmps(original, previous, base_vertical_edges, previous_current_edges, previous_intersection_mask, false);
+        BMP current_diff = PixelBasher::compare_bmps(original, current, false);
+        BMP previous_diff = PixelBasher::compare_bmps(original, previous, false);
         BMP diff = PixelBasher::compare_regressions(original, current_diff, previous_diff);
 
         int diff_size = diff.get_width() * diff.get_height();

--- a/test/test_pixelbasher.cpp
+++ b/test/test_pixelbasher.cpp
@@ -8,7 +8,11 @@ TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
         BMP original("test_data/solid_white.bmp");
         BMP target("test_data/vertical_edges.bmp");
 
-        BMP diff = PixelBasher::compare_bmps(original, target, false);
+        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
+        std::vector<bool> target_vertical_edges = target.get_filtered_vertical_edge_mask();
+        std::vector<bool> intersection_mask = BMP::calculate_intersection_mask(original, target);
+
+        BMP diff = PixelBasher::compare_bmps(original, target, base_vertical_edges, target_vertical_edges, intersection_mask, false);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -19,7 +23,11 @@ TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
         BMP original("test_data/solid_white.bmp");
         BMP target("test_data/solid_white.bmp");
 
-        BMP diff = PixelBasher::compare_bmps(original, target, false);
+        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
+        std::vector<bool> target_vertical_edges = target.get_filtered_vertical_edge_mask();
+        std::vector<bool> intersection_mask = BMP::calculate_intersection_mask(original, target);
+
+        BMP diff = PixelBasher::compare_bmps(original, target, base_vertical_edges, target_vertical_edges, intersection_mask, false);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -30,7 +38,11 @@ TEST_CASE("PixelBasher compare two BMP's", "[pixelbasher][compare]") {
         BMP original("test_data/text.bmp");
         BMP target("test_data/slightly-different-text.bmp");
 
-        BMP diff = PixelBasher::compare_bmps(original, target, true);
+        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
+        std::vector<bool> target_vertical_edges = target.get_filtered_vertical_edge_mask();
+        std::vector<bool> intersection_mask = BMP::calculate_intersection_mask(original, target);
+
+        BMP diff = PixelBasher::compare_bmps(original, target, base_vertical_edges, target_vertical_edges, intersection_mask, true);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -44,9 +56,16 @@ TEST_CASE("PixelBasher compare regression", "[pixelbasher][regression]") {
         BMP current("test_data/solid_black.bmp");
         BMP previous("test_data/vertical_edges.bmp");
 
-        BMP current_diff = PixelBasher::compare_bmps(original, current, false);
-        BMP previous_diff = PixelBasher::compare_bmps(original, previous, false);
-        BMP diff = PixelBasher::compare_regressions(original, current_diff, previous_diff   );
+        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
+        std::vector<bool> current_vertical_edges = current.get_filtered_vertical_edge_mask();
+        std::vector<bool> previous_current_edges = previous.get_filtered_vertical_edge_mask();
+
+        std::vector<bool> current_intersection_mask = BMP::calculate_intersection_mask(original, current);
+        std::vector<bool> previous_intersection_mask = BMP::calculate_intersection_mask(original, previous);
+
+        BMP current_diff = PixelBasher::compare_bmps(original, current, base_vertical_edges, current_vertical_edges, current_intersection_mask, false);
+        BMP previous_diff = PixelBasher::compare_bmps(original, current, base_vertical_edges, previous_current_edges, previous_intersection_mask, false);
+        BMP diff = PixelBasher::compare_regressions(original, current_diff, previous_diff);
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
@@ -59,11 +78,19 @@ TEST_CASE("PixelBasher compare regression", "[pixelbasher][regression]") {
         BMP current("test_data/solid_white.bmp");
         BMP previous("test_data/solid_black.bmp");
 
-        BMP current_diff = PixelBasher::compare_bmps(original, current, false);
-        BMP previous_diff = PixelBasher::compare_bmps(original, previous, false);
+        std::vector<bool> base_vertical_edges = original.get_filtered_vertical_edge_mask();
+        std::vector<bool> current_vertical_edges = current.get_filtered_vertical_edge_mask();
+        std::vector<bool> previous_current_edges = previous.get_filtered_vertical_edge_mask();
+
+        std::vector<bool> current_intersection_mask = BMP::calculate_intersection_mask(original, current);
+        std::vector<bool> previous_intersection_mask = BMP::calculate_intersection_mask(original, previous);
+
+        BMP current_diff = PixelBasher::compare_bmps(original, current, base_vertical_edges, current_vertical_edges, current_intersection_mask, false);
+        BMP previous_diff = PixelBasher::compare_bmps(original, previous, base_vertical_edges, previous_current_edges, previous_intersection_mask, false);
         BMP diff = PixelBasher::compare_regressions(original, current_diff, previous_diff);
 
         int diff_size = diff.get_width() * diff.get_height();
+
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);
         REQUIRE(diff.get_green_count() == diff_size);

--- a/test/test_pixelbasher.cpp
+++ b/test/test_pixelbasher.cpp
@@ -44,11 +44,9 @@ TEST_CASE("PixelBasher compare regression", "[pixelbasher][regression]") {
         BMP current("test_data/solid_black.bmp");
         BMP previous("test_data/vertical_edges.bmp");
 
-        BMP current_diff = PixelBasher::compare_bmps(original, current,  false);
+        BMP current_diff = PixelBasher::compare_bmps(original, current, false);
         BMP previous_diff = PixelBasher::compare_bmps(original, previous, false);
         BMP diff = PixelBasher::compare_regressions(original, current_diff, previous_diff);
-
-        diff.write("test_data/output/new-diff.bmp");
 
         REQUIRE(diff.get_width() == 50); // <= original.get_width()
         REQUIRE(diff.get_height() == 50);


### PR DESCRIPTION
This the flame graph pre changes

<img width="220" height="174" alt="image" src="https://github.com/user-attachments/assets/d87f84f0-76f6-4a5b-94c0-9d15edaec907" />

This is just a work in progress change, but In the flame graph `recalculate_masks` contributes to a significant amount of CPU usage. My thought process is that, we can sacrifice storing them as member variables and thus are not forced to recalculate them every time set_data is called. It worked quite well, reducing the execution time on a run from 19 seconds to 13 seconds.

However, It has lead to significantly more code and repetition especially in `main`/tests. So I was wondering, is the trade-off worth it and/or a better way to go about it.

I've got other ideas on improving performance, which I'll starting working on them by the beginning of next week :)